### PR TITLE
Add support of Valgrind to check the memory issue

### DIFF
--- a/.valgrindrc
+++ b/.valgrindrc
@@ -1,0 +1,4 @@
+--quiet
+--memcheck:leak-check=full
+--show-leak-kinds=all
+--error-exitcode=1

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,14 @@ qtest: qtest.c report.c console.c harness.c queue.o
 test: qtest scripts/driver.py
 	scripts/driver.py
 
+valgrind_existence:
+	@which valgrind 2>&1 > /dev/null
+
+valgrind: qtest valgrind_existence
+	cp qtest qtest.patched
+	sed -i "s/alarm/isnan/g" qtest.patched
+	scripts/driver.py -p ./qtest.patched --valgrind
+
 clean:
 	rm -f *.o *~ qtest 
 	rm -rf *.dSYM

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,17 @@ valgrind_existence:
 	@which valgrind 2>&1 > /dev/null
 
 valgrind: qtest valgrind_existence
-	cp qtest qtest.patched
-	sed -i "s/alarm/isnan/g" qtest.patched
-	scripts/driver.py -p ./qtest.patched --valgrind
+	$(eval patched_file := $(shell mktemp /tmp/qtest.XXXXXX))
+	cp qtest $(patched_file)
+	chmod u+x $(patched_file)
+	sed -i "s/alarm/isnan/g" $(patched_file)
+	scripts/driver.py -p $(patched_file) --valgrind
+	@echo
+	@echo "Test with specific case by running command:" 
+	@echo "scripts/driver.py -p $(patched_file) --valgrind -t <tid>"
 
 clean:
-	rm -f *.o *~ qtest 
+	rm -f *.o *~ qtest /tmp/qtest.*
 	rm -rf *.dSYM
 	(cd traces; rm -f *~)
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Check the correctness of your code:
 make test
 ```
 
+Check the memory issue of your code (modify `./.valgrindrc` to customize arguments of Valgrind):
+
+```shell
+make valgrind
+```
+
 ## Using qtest
 
 qtest provides a command interpreter that can create and manipulate queues.

--- a/README.md
+++ b/README.md
@@ -13,11 +13,14 @@ Check the correctness of your code:
 make test
 ```
 
-Check the memory issue of your code (modify `./.valgrindrc` to customize arguments of Valgrind):
+Check the memory issue of your code:
 
 ```shell
 make valgrind
 ```
+
+* Modify `./.valgrindrc` to customize arguments of Valgrind
+* Use `make clean` or `rm /tmp/qtest.*` to clean the temporary files created by target valgrind
 
 ## Using qtest
 


### PR DESCRIPTION
scripts/driver.py will use Valgrind to run each unittest when option
--valgrind is provided. This commit add two members to class Tracer, a
flag for option --valgrind and a string to represent the main command
for subprocess.call().

Notices:

- Remember to patch alarm function used in harness.c since Valgrind will
  inject extra code during the execution which may cause invocation of
  alarm.
  There are several ways of patching.
    - Replace alarm by isnan in executable.
    - Increase the value of variable `time_limit` declared in harness.c.
    - Remove the alarm function in harness.c.