### PR TITLE
Check entire buffer in check overflow

### DIFF
--- a/qtest.c
+++ b/qtest.c
@@ -300,15 +300,11 @@ bool do_remove_head(int argc, char *argv[])
           Validate memory by checking removes's padding positions are still
           initial value 'X'.
         */
-        bool check_overflow = true;
-        for (int i = string_length + 1; i < string_length + STRINGPAD; i++) {
-            if (removes[i] != 'X') {
-                check_overflow = false;
-                break;
-            }
+        int i = string_length + 1;
+        while (i < string_length + STRINGPAD && removes[i] == 'X') {
+            i++;
         }
-
-        if (!check_overflow) {
+        if (i != string_length + STRINGPAD) {
             report(1,
                    "ERROR: copying of string in remove_head overflowed "
                    "destination buffer.");

--- a/qtest.c
+++ b/qtest.c
@@ -297,8 +297,7 @@ bool do_remove_head(int argc, char *argv[])
         }
 
         bool check_overflow = true;
-        int i = 0;
-        for (i = string_length + 1; i < string_length + STRINGPAD; i++) {
+        for (int i = string_length + 1; i < string_length + STRINGPAD; i++) {
             if (removes[i] != 'X') {
                 check_overflow = false;
                 break;

--- a/qtest.c
+++ b/qtest.c
@@ -296,6 +296,10 @@ bool do_remove_head(int argc, char *argv[])
             ok = false;
         }
 
+        /*
+        Validate memory by checking removes's padding positions are still
+        initial value 'X'.
+        */
         bool check_overflow = true;
         for (int i = string_length + 1; i < string_length + STRINGPAD; i++) {
             if (removes[i] != 'X') {

--- a/qtest.c
+++ b/qtest.c
@@ -301,7 +301,7 @@ bool do_remove_head(int argc, char *argv[])
           initial value 'X'.
         */
         int i = string_length + 1;
-        while (i < string_length + STRINGPAD && removes[i] == 'X') {
+        while ((i < string_length + STRINGPAD) && (removes[i] == 'X')) {
             i++;
         }
         if (i != string_length + STRINGPAD) {

--- a/qtest.c
+++ b/qtest.c
@@ -294,7 +294,18 @@ bool do_remove_head(int argc, char *argv[])
         if (removes[0] == '\0') {
             report(1, "ERROR: Failed to store removed value");
             ok = false;
-        } else if (removes[string_length + 1] != 'X') {
+        }
+
+        bool check_overflow = true;
+        int i = 0;
+        for (i = string_length + 1; i < string_length + STRINGPAD; i++) {
+            if (removes[i] != 'X') {
+                check_overflow = false;
+                break;
+            }
+        }
+
+        if (!check_overflow) {
             report(1,
                    "ERROR: copying of string in remove_head overflowed "
                    "destination buffer.");

--- a/qtest.c
+++ b/qtest.c
@@ -297,8 +297,8 @@ bool do_remove_head(int argc, char *argv[])
         }
 
         /*
-          Validate memory by checking removes's padding positions are still
-          initial value 'X'.
+          Check whether padding in array removes are still initial value 'X'. If
+          there's other character in padding, it's overflowed.
         */
         int i = string_length + 1;
         while ((i < string_length + STRINGPAD) && (removes[i] == 'X')) {

--- a/qtest.c
+++ b/qtest.c
@@ -297,8 +297,8 @@ bool do_remove_head(int argc, char *argv[])
         }
 
         /*
-        Validate memory by checking removes's padding positions are still
-        initial value 'X'.
+          Validate memory by checking removes's padding positions are still
+          initial value 'X'.
         */
         bool check_overflow = true;
         for (int i = string_length + 1; i < string_length + STRINGPAD; i++) {


### PR DESCRIPTION
do_remove_head() checked removes[string_length + 1] only, so
q_remove_head() would pass the test when it try to write data to other
place in the buffer, such as index string_length + 2. Check entire
buffer to fix it.