### PR TITLE
Prevent test_free treat free(NULL) as error

### DIFF
--- a/harness.c
+++ b/harness.c
@@ -154,8 +154,6 @@ void test_free(void *p)
         return;
     }
     if (p == NULL) {
-        report(MSG_ERROR, "Attempt to free NULL");
-        error_occurred = true;
         return;
     }
     block_ele_t *b = find_header(p);


### PR DESCRIPTION
In man page of free, "If ptr is NULL, no operation is performed."
We should not treat free(NULL) as error, thus removing marking error,
  just align the behavior of native free, perform no operation.