### PR TITLE
Fix(trace): fix expected values and unknown address access

### DIFF
--- a/qtest.c
+++ b/qtest.c
@@ -485,16 +485,18 @@ bool do_sort(int argc, char *argv[])
     exception_cancel();
     set_noallocate_mode(false);
 
-    list_ele_t *e = q->head;
     bool ok = true;
-    while (ok && e && --cnt) {
-        /* Ensure each element in ascending order */
-        /* FIXME: add an option to specify sorting order */
-        if (strcmp(e->value, e->next->value) > 0) {
-            report(1, "ERROR: Not sorted in ascending order");
-            ok = false;
+    if (q) {
+        list_ele_t *e = q->head;
+        while (ok && e && --cnt) {
+            /* Ensure each element in ascending order */
+            /* FIXME: add an option to specify sorting order */
+            if (strcmp(e->value, e->next->value) > 0) {
+                report(1, "ERROR: Not sorted in ascending order");
+                ok = false;
+            }
+            e = e->next;
         }
-        e = e->next;
     }
 
     show_queue(3);

--- a/traces/trace-04-ops.cmd
+++ b/traces/trace-04-ops.cmd
@@ -11,7 +11,7 @@ it bear
 it gerbil
 size
 sort
-rh dolphin
+rh bear
 rh
 rh
 rh

--- a/traces/trace-05-ops.cmd
+++ b/traces/trace-05-ops.cmd
@@ -15,10 +15,10 @@ rh dolphin
 reverse
 size
 sort
-rh gerbil
 rh bear
+rh bear
+rh gerbil
+rh gerbil
 rh meerkat
-rh gerbil
-rh bear
 size
 free


### PR DESCRIPTION
## Why
1. The expected values should be changed after the sorting operation.
2. `do_sort` will access unknown memory address if the queue is null.

## How
1. Fix the expected values of trace-4, trace-5.
2. always return true if it is a null queue.