### PR TITLE
Feature: add random insert cmd and a test case for sorting performance

### DIFF
--- a/scripts/driver.py
+++ b/scripts/driver.py
@@ -29,7 +29,8 @@ class Tracer:
         12 : "trace-12-malloc",
         13 : "trace-13-perf",
         14 : "trace-14-perf",
-        15 : "trace-15-perf"
+        15 : "trace-15-perf",
+        16 : "trace-16-perf"
         }
 
     traceProbs = {
@@ -47,11 +48,12 @@ class Tracer:
         12 : "Trace-12",
         13 : "Trace-13",
         14 : "Trace-14",
-        15 : "Trace-15"
+        15 : "Trace-15",
+        16 : "Trace-16"
         }
 
 
-    maxScores = [0, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7]
+    maxScores = [0, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7]
 
     def __init__(self, qtest = "", verbLevel = 0, autograde = False, useValgrind = False):
         if qtest != "":

--- a/traces/trace-16-perf.cmd
+++ b/traces/trace-16-perf.cmd
@@ -1,0 +1,6 @@
+# Test performance of sort
+option fail 0
+option malloc 0
+new
+randi 100000 DESC
+sort


### PR DESCRIPTION
## Why
Test the worst case of sorting. 

## How
1. Add a `randi` cmd to insert the large number of words with DESC order.
2. Add the `trace-16-perf.cmd `  test file for sorting test.

## Todo
maxScores should be changed. Cause the total score now is 107 haha.