### PR TITLE
Add necessary header for queue.h

### DIFF
--- a/queue.h
+++ b/queue.h
@@ -9,6 +9,7 @@
  */
 
 #include <stdbool.h>
+#include <stddef.h>
 
 /* Data structure declarations */
 


### PR DESCRIPTION
the order of headers should not affect the compilation.
if no stddef.h in queue.h, we might have the error when adjusting
the order:

In file included from queue.c:2:
./queue.h:73:42: error: unknown type name 'size_t'
bool q_remove_head(queue_t *q, char *sp, size_t bufsize);