### PR TITLE
Modify redefinition of strdup

### DIFF
--- a/harness.h
+++ b/harness.h
@@ -63,6 +63,9 @@ void trigger_exception(char *msg);
 /* Tested program use our versions of malloc and free */
 #define malloc test_malloc
 #define free test_free
+
+/* Use undef to avoid strdup redefined error */
+#undef strdup
 #define strdup test_strdup
 
 #endif


### PR DESCRIPTION
There are two definitions of strdup in harness.h
and string2.h. This will cause a redefined error
when compile. Using macro #undef to undef the
strdup defined in string2.h:1291.