### PR TITLE
Support colored text while reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ check: qtest
 	./$< -v 3 -f traces/trace-eg.cmd
 
 test: qtest scripts/driver.py
-	scripts/driver.py
+	scripts/driver.py -c
 
 valgrind_existence:
 	@which valgrind 2>&1 > /dev/null || (echo "FATAL: valgrind not found"; exit 1)

--- a/scripts/driver.py
+++ b/scripts/driver.py
@@ -16,7 +16,7 @@ class Tracer:
     verbLevel = 0
     autograde = False
     useValgrind = False
-    colorFul = False
+    colored = False
 
     traceDict = {
         1: "trace-01-ops",
@@ -69,16 +69,16 @@ class Tracer:
                  verbLevel=0,
                  autograde=False,
                  useValgrind=False,
-                 colorFul=False):
+                 colored=False):
         if qtest != "":
             self.qtest = qtest
         self.verbLevel = verbLevel
         self.autograde = autograde
         self.useValgrind = useValgrind
-        self.colorFul = colorFul
+        self.colored = colored
 
     def printInColor(self, text, color):
-        if self.colorFul == False:
+        if self.colored == False:
             color = self.WHITE
         print(color, text, self.WHITE, sep = '')
 
@@ -149,7 +149,7 @@ def usage(name):
     print("  -p PROG   Program to test")
     print("  -t TID    Trace ID to test")
     print("  -v VLEVEL Set verbosity level (0-3)")
-    print("  -c Print colored text in terminal")
+    print("  -c Enable colored text")
     sys.exit(0)
 
 
@@ -160,7 +160,7 @@ def run(name, args):
     levelFixed = False
     autograde = False
     useValgrind = False
-    colorFul = False
+    colored = False
 
     optlist, args = getopt.getopt(args, 'hp:t:v:A:c', ['valgrind'])
     for (opt, val) in optlist:
@@ -178,7 +178,7 @@ def run(name, args):
         elif opt == '--valgrind':
             useValgrind = True
         elif opt == '-c':
-            colorFul = True
+            colored = True
         else:
             print("Unrecognized option '%s'" % opt)
             usage(name)
@@ -188,7 +188,7 @@ def run(name, args):
                verbLevel=vlevel,
                autograde=autograde,
                useValgrind=useValgrind,
-               colorFul=colorFul)
+               colored=colored)
     t.run(tid)
 
 

--- a/scripts/driver.py
+++ b/scripts/driver.py
@@ -70,7 +70,7 @@ class Tracer:
 
     def runTrace(self, tid):
         if not tid in self.traceDict:
-            print("ERROR: No trace with id %d" % tid)
+            print("\033[91mERROR: No trace with id %d" % tid)
             return False
         fname = "%s/%s.cmd" % (self.traceDirectory, self.traceDict[tid])
         vname = "%d" % self.verbLevel
@@ -78,7 +78,7 @@ class Tracer:
         try:
             retcode = subprocess.call(clist)
         except Exception as e:
-            print("Call of '%s' failed: %s" % (" ".join(clist), e))
+            print("\033[91mCall of '%s' failed: %s" % (" ".join(clist), e))
             return False
         return retcode == 0
 
@@ -89,7 +89,7 @@ class Tracer:
             tidList = self.traceDict.keys()
         else:
             if not tid in self.traceDict:
-                print("ERROR: Invalid trace ID %d" % tid)
+                print("\033[91mERROR: Invalid trace ID %d" % tid)
                 return
             tidList = [tid]
         score = 0
@@ -101,15 +101,21 @@ class Tracer:
         for t in tidList:
             tname = self.traceDict[t]
             if self.verbLevel > 0:
-                print("+++ TESTING trace %s:" % tname)
+                print("\033[0m+++ TESTING trace %s:" % tname)
             ok = self.runTrace(t)
             maxval = self.maxScores[t]
             tval = maxval if ok else 0
-            print("---\t%s\t%d/%d" % (tname, tval, maxval))
+            if tval < maxval:
+                print("\033[91m---\t%s\t%d/%d" % (tname, tval, maxval))
+            else:
+                print("\033[92m---\t%s\t%d/%d" % (tname, tval, maxval)) 
             score += tval
             maxscore += maxval
             scoreDict[t] = tval
-        print("---\tTOTAL\t\t%d/%d" % (score, maxscore))
+        if score < maxscore:
+            print("\033[91m---\tTOTAL\t\t%d/%d" % (score, maxscore))
+        else:
+            print("\033[92m---\tTOTAL\t\t%d/%d" % (score, maxscore))
         if self.autograde:
             # Generate JSON string
             jstring = '{"scores": {'


### PR DESCRIPTION
`\033[91m` for failure testing (red)
`\033[0m` for resetting color (white)
`\033[92m` for successful testing (green)

<img src="https://user-images.githubusercontent.com/37936015/75059110-421c9680-5517-11ea-8cdb-c0e81730632b.png" width="480">
<img src="https://user-images.githubusercontent.com/37936015/75059115-42b52d00-5517-11ea-98e5-30c142c6fb56.png" width="480">