### PR TITLE
Find the problem of driver and fix that

### DIFF
--- a/scripts/driver.py
+++ b/scripts/driver.py
@@ -88,7 +88,7 @@ class Tracer:
             return False
         fname = "%s/%s.cmd" % (self.traceDirectory, self.traceDict[tid])
         vname = "%d" % self.verbLevel
-        clist = [self.command, "-v", vname, "-f", fname]
+        clist = [self.command, self.qtest, "-v", vname, "-f", fname]
         try:
             retcode = subprocess.call(clist)
         except Exception as e:
@@ -109,7 +109,7 @@ class Tracer:
         score = 0
         maxscore = 0
         if self.useValgrind:
-            self.command = 'valgrind ' + self.qtest
+            self.command = "valgrind"
         else:
             self.command = self.qtest
         for t in tidList:


### PR DESCRIPTION
The problem is caused by subprocess.call().
It can't revieve self.command which has been
assigned to "valgrind"+self.qtest as parameter.
Subprocess.call() will treat that as path of program.

Therefore, I change the position of self.qtest to
fix the problem.