### PR TITLE
Fix driver script error caused by macOS specific changes

### DIFF
--- a/scripts/driver.py
+++ b/scripts/driver.py
@@ -88,7 +88,8 @@ class Tracer:
             return False
         fname = "%s/%s.cmd" % (self.traceDirectory, self.traceDict[tid])
         vname = "%d" % self.verbLevel
-        clist = [self.command, "-v", vname, "-f", fname]
+        clist = self.command + ["-v", vname, "-f", fname]
+        
         try:
             retcode = subprocess.call(clist)
         except Exception as e:
@@ -109,9 +110,9 @@ class Tracer:
         score = 0
         maxscore = 0
         if self.useValgrind:
-            self.command = 'valgrind ' + self.qtest
+            self.command = ['valgrind', self.qtest]
         else:
-            self.command = self.qtest
+            self.command = [self.qtest]
         for t in tidList:
             tname = self.traceDict[t]
             if self.verbLevel > 0:


### PR DESCRIPTION
Checked both `make test`, `make valgrind` on Linux/debian10,
`make test` on macOSX 10.15.3(no valgrind support at the moment)
Sorry, I forgot to check if the valgrind target still working on Linux after the fix.