### PR TITLE
Show the clang-format summary of files

### DIFF
--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -63,6 +63,9 @@ for FILE in $FILES; do
     fi
 done
 
+echo "Following files need to be cleaned up:"
+echo "${FILES[*]}"
+
 # Prevent unsafe functions
 root=$(git rev-parse --show-toplevel)
 banned="([^f]gets\()|(sprintf\()|(strcpy\()"


### PR DESCRIPTION
Show all files at the end of git-commit hook message.
It could avoid scroll up to find each failing file.