### PR TITLE
Fix system calling issue

### DIFF
--- a/scripts/driver.py
+++ b/scripts/driver.py
@@ -76,7 +76,7 @@ class Tracer:
         vname = "%d" % self.verbLevel
         clist = [self.command, "-v", vname, "-f", fname]
         try:
-            retcode = subprocess.call(clist)
+            retcode = subprocess.call(" ".join(clist), shell=True)
         except Exception as e:
             print("Call of '%s' failed: %s" % (" ".join(clist), e))
             return False


### PR DESCRIPTION
When passing clist to subprocess.call(),
under some circumstances (unknown) will cause
File or Directory Not Found error.

I fix this by concatenate clist into string
and pass shell=True as the second argument.