### PR TITLE
Fix the unknown option in Valgrind

### DIFF
--- a/.valgrindrc
+++ b/.valgrindrc
@@ -1,4 +1,4 @@
 --quiet
 --memcheck:leak-check=full
---show-leak-kinds=all
+--memcheck:show-leak-kinds=all
 --error-exitcode=1


### PR DESCRIPTION
While using massif in valgrind, like below
```
valgrind --tool=massif ./qtest
```

It would return `Unknown option: --show-leak-kinds=all`
In fact, the option `show-leak-kinds` should be called in `memcheck`
Just like `memcheck:leak-check=full`

So, change `--show-leak-kinds=all` to `--memcheck:show-leak-kinds=all`