### PR TITLE
Refine statement-like macro definitions

### DIFF
--- a/dudect/constant.h
+++ b/dudect/constant.h
@@ -2,35 +2,29 @@
 #define DUDECT_CONSTANT_H
 
 #include <stdint.h>
-#define dut_new()    \
-    {                \
-        q = q_new(); \
-    }
+#define dut_new() ((void) (q = q_new()))
 
 #define dut_size(n)                                \
     do {                                           \
         for (int __iter = 0; __iter < n; ++__iter) \
             q_size(q);                             \
-    } while (0);
+    } while (0)
 
 #define dut_insert_head(s, n)    \
     do {                         \
         int j = n;               \
         while (j--)              \
             q_insert_head(q, s); \
-    } while (0);
+    } while (0)
 
 #define dut_insert_tail(s, n)    \
     do {                         \
         int j = n;               \
         while (j--)              \
             q_insert_tail(q, s); \
-    } while (0);
+    } while (0)
 
-#define dut_free() \
-    {              \
-        q_free(q); \
-    }
+#define dut_free() ((void) (q_free(q)))
 
 void init_dut();
 void prepare_inputs(uint8_t *input_data, uint8_t *classes);


### PR DESCRIPTION
### Remove the trailing `;` in the definition of function-like macros.

Programmers who are unaware that these "functions" are actually macros might write something seemly innocent such as:
```cpp
if (remove_front)
    dut_insert_head(s, n);
else
    dut_insert_tail(s, n);
```

But it will then expand to something disastrous:
```cpp
if (remove_front)
    do {                         \
        int j = n;               \
        while (j--)              \
            q_insert_head(q, s); \
    } while (0);;
else
    do {                         \
        int j = n;               \
        while (j--)              \
            q_insert_tail(q, s); \
    } while (0);;
```
(These backslashes at line ends are keeped for readability.
 In reality, these backslashes will be removed at translation phase 2, before the preprocessor is executed at translation phase 4)

Note that how the semicolon `;` the programmers put after `dut_insert_head()` terminates the `if` block, leaving the `else` dangling.

The idiom `do { } while (0)` was meant for dealing with this issue, but the trailing semicolon ruined it.

The removal of the trailing semicolon fixes this issue.

### Rewrite the definition of some function-like macros into expression.

This avoids the aforementioned issue and makes constructs such as `dut_new(), dut_free()` valid.

There are 2 reasons why these macros are defined like this:
```cpp
    #define dut_new() ((void) (q = q_new(q)))
```

1. To prevent invoking functions without parentheses.

If the macro were defined just as `(q = q_new(q))`, the programmers could write `q_size dut_new()` and later confuse themselves.

A cast to `void` prevents such problem, since a function cannot be invoked with any `void` arguments.

(The function `q_free()` already returns `void`, so the cast in the macro `dut_free()` is actually redundant)

2. To ensure that the cast occurs before suffix operations on the macro.

If the macro were defined as `(void) (q = q_new(q))`, the programmers could write `dut_new()->head++` which compiles.
Later when they rewrite it into `++dut_new()->head`, they will be confused, because the rewritten one does not compile.

A pair of parentheses enclosing the cast avoids such possibility by making suffix operations on the macro to occur after the cast.