### PR TITLE
Change Cppcheck version is at least 1.90

### DIFF
--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -15,10 +15,9 @@ if [ $? -ne 0 ]; then
     echo "[!] cppcheck not installed. Unable to perform static analysis." >&2
     exit 1
 fi
-# Expected Cppcheck version is 1.90
-# FIXME: extract version number for 2.xx
-CPPCHECK_VER=$($CPPCHECK --version | sed -Ee 's/Cppcheck 1.([0-9]+)/\1/;q')
-if [ $CPPCHECK_VER -lt 90 ]; then
+# Expected Cppcheck version is at least 1.90
+CPPCHECK_VER=$($CPPCHECK --version | sed -Ee 's/Cppcheck ([0-9]).([0-9]+)/\1*100+\2/;q' | bc -l)
+if [ $CPPCHECK_VER -lt 190 ]; then
     echo "[!] cppcheck version must be at least 1.90." >&2
     echo -e "    Check 'Developer Info' for building Cppcheck from source:\n" \
             "          http://cppcheck.sourceforge.net/devinfo/" >&2

--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -16,7 +16,8 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 # Expected Cppcheck version is at least 1.90
-CPPCHECK_VER=$($CPPCHECK --version | sed -Ee 's/Cppcheck ([0-9]).([0-9]+)/\1*100+\2/;q' | bc -l)
+N=2
+CPPCHECK_VER=$($CPPCHECK --version | sed -rEe ":r;s/\b[0-9]{1,$(($N-1))}\b/0&/;tr;s/Cppcheck ([0-9]+).([0-9]+)/\1\2/;q")
 if [ $CPPCHECK_VER -lt 190 ]; then
     echo "[!] cppcheck version must be at least 1.90." >&2
     echo -e "    Check 'Developer Info' for building Cppcheck from source:\n" \


### PR DESCRIPTION
The current Cppcheck version check must be 1.x and at least 1.90 . However, the latest version of Cppcheck already has 2.x, so the regular expression has been modified to support versions 2.0 later.