### PR TITLE
Fix the size to be cleaned in prepare_inputs

### DIFF
--- a/dudect/constant.c
+++ b/dudect/constant.c
@@ -42,7 +42,7 @@ void prepare_inputs(uint8_t *input_data, uint8_t *classes)
     for (size_t i = 0; i < number_measurements; i++) {
         classes[i] = randombit();
         if (classes[i] == 0)
-            *(uint16_t *) (input_data + i * chunk_size) = 0x00;
+            memset(input_data + (size_t) i * chunk_size, 0, chunk_size);
     }
 
     for (size_t i = 0; i < NR_MEASURE; ++i) {


### PR DESCRIPTION
In dudect/constant.c, to do the test, we must first distribute all data
into two classes, fixed and random class. If the one is distributed to 0,
it means it belongs to random class and we should clean the relating
input_data to 0.

But in this Implementation, a single size of an element in input_data is
`chunk_size`, which means it is 16 byte. However, in dudect/constant.c,
it only clean up an `uint16_t` size, which is 2 byte only.

To fix this problem, I use `memset` to reset the whole element to 0.