### PR TITLE
Fix bug of qtest and extend for completion

### DIFF
--- a/console.h
+++ b/console.h
@@ -78,4 +78,7 @@ int cmd_select(int nfds,
  */
 bool run_console(char *infile_name);
 
+/* Callback function to complete command by linenoise */
+void completion(const char *buf, linenoiseCompletions *lc);
+
 #endif /* LAB0_CONSOLE_H */

--- a/linenoise.c
+++ b/linenoise.c
@@ -1327,29 +1327,3 @@ int linenoiseHistoryLoad(const char *filename)
     fclose(fp);
     return 0;
 }
-int completion_helper(const char *target, const char *cur)
-{
-    int res = 1;
-    for (int i = 0, j = 0; i < strlen(cur); i++, j++) {
-        if (cur[i] != target[j])
-            res = 0;
-    }
-    return res;
-}
-void completion(const char *buf, linenoiseCompletions *lc)
-{
-    if (completion_helper("help", buf)) {
-        linenoiseAddCompletion(lc, "help");
-    } else if (completion_helper("free", buf)) {
-        linenoiseAddCompletion(lc, "free");
-    } else if (completion_helper("ih", buf)) {
-        linenoiseAddCompletion(lc, "ih");
-    } else if (completion_helper("it", buf)) {
-        linenoiseAddCompletion(lc, "it");
-    } else if (completion_helper("new", buf)) {
-        linenoiseAddCompletion(lc, "new");
-    } else if (completion_helper("reverse", buf)) {
-        linenoiseAddCompletion(lc, "reverse");
-    }
-    /* append more command if you want */
-}

--- a/linenoise.h
+++ b/linenoise.h
@@ -68,8 +68,6 @@ void linenoiseSetMultiLine(int ml);
 void linenoisePrintKeyCodes(void);
 void linenoiseMaskModeEnable(void);
 void linenoiseMaskModeDisable(void);
-void completion(const char *buf, linenoiseCompletions *lc);
-int completion_helper(const char *target, const char *cur);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
A small bug is found and fixed for the previous PR, which extend the use of linenoise to `qtest`. The bug is: a single `Ctrl+C` won't close the terminal immediately.

Also, there's some revise for the callback function `completion`  in `linenoiseSetCompletionCallback(completion)`. In the new implementation, `completion` will iterate the struct `param_ptr` and `cmd_ptr`, using them to complete input command and also parameters of command `option`. So when a new command or parameters are registered by `add_cmd` or `add_param`, it could be automatically figured out by linenoise API.