### PR TITLE
Improve the test of trace-05

### DIFF
--- a/traces/trace-05-ops.cmd
+++ b/traces/trace-05-ops.cmd
@@ -15,10 +15,14 @@ rh dolphin
 reverse
 size
 sort
-rh bear
-rh bear
-rh gerbil
-rh gerbil
+it fish
+reverse
+rh fish
 rh meerkat
+reverse
+rh bear
+rh bear
+rh gerbil
+rh gerbil
 size
 free


### PR DESCRIPTION
Originally, we could pass trace-05 without setting `q->tail` correctly.