### PR TITLE
Fix commit hook check auto generated diffs

### DIFF
--- a/scripts/commit-msg.hook
+++ b/scripts/commit-msg.hook
@@ -118,6 +118,9 @@ read_commit_message() {
     [[ $REPLY =~ ^# ]]
     test $? -eq 0 || COMMIT_MSG_LINES+=("$REPLY")
 
+    [[ $REPLY =~ "# ------------------------ >8 ------------------------" ]]
+    break
+
   done < $COMMIT_MSG_FILE
 }
 


### PR DESCRIPTION
When uses `git commit -v`, there are auto generated diffs that is excluded in commit log. Thus these messages should also be excluded by the commit hook. 