### PR TITLE
Avoid global buffer overflow

### DIFF
--- a/console.c
+++ b/console.c
@@ -18,7 +18,7 @@
 #include "report.h"
 
 /* Some global values */
-bool simulation = false;
+int simulation = 0;
 static cmd_ptr cmd_list = NULL;
 static param_ptr param_list = NULL;
 static bool block_flag = false;
@@ -56,7 +56,7 @@ static int fd_max = 0;
 /* Parameters */
 static int err_limit = 5;
 static int err_cnt = 0;
-static bool echo = 0;
+static int echo = 0;
 
 static bool quit_flag = false;
 static char *prompt = "cmd> ";
@@ -101,11 +101,10 @@ void init_cmd()
     add_cmd("log", do_log_cmd, " file           | Copy output to file");
     add_cmd("time", do_time_cmd, " cmd arg ...    | Time command execution");
     add_cmd("#", do_comment_cmd, " ...            | Display comment");
-    add_param("simulation", (int *) &simulation, "Start/Stop simulation mode",
-              NULL);
+    add_param("simulation", &simulation, "Start/Stop simulation mode", NULL);
     add_param("verbose", &verblevel, "Verbosity level", NULL);
     add_param("error", &err_limit, "Number of errors until exit", NULL);
-    add_param("echo", (int *) &echo, "Do/don't echo commands", NULL);
+    add_param("echo", &echo, "Do/don't echo commands", NULL);
 
     init_in();
     init_time(&last_time);

--- a/console.h
+++ b/console.h
@@ -8,7 +8,7 @@
 /* Implementation of simple command-line interface */
 
 /* Simulation flag of console option */
-extern bool simulation;
+extern int simulation;
 
 /* Each command defined in terms of a function */
 typedef bool (*cmd_function)(int argc, char *argv[]);


### PR DESCRIPTION
To avoid global buffer overflow when compiling with SANITIZER=1,
this commit replaces bool type with integer type.

close #32 