### PR TITLE
Fix comment inconsistency

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -99,7 +99,8 @@ int q_size(struct list_head *head)
  * The middle node of a linked list of size n is the
  * ⌊n / 2⌋th node from the start using 0-based indexing.
  * If there're six element, the third member should be return.
- * Return NULL if list is NULL or empty.
+ * Return true if successful.
+ * Return false if list is NULL or empty.
  */
 bool q_delete_mid(struct list_head *head)
 {


### PR DESCRIPTION
Modify q_delete_mid() comment in queue.c to make it consistent with
return type.