### PR TITLE
Fix unexpected verbose result

### DIFF
--- a/scripts/driver.py
+++ b/scripts/driver.py
@@ -142,7 +142,8 @@ class Tracer:
                 jstring += '"%s" : %d' % (self.traceProbs[k], scoreDict[k])
             jstring += '}}'
             print(jstring)
-
+        if score < maxscore:
+            sys.exit(1)
 
 def usage(name):
     print("Usage: %s [-h] [-p PROG] [-t TID] [-v VLEVEL] [--valgrind] [-c]" % name)


### PR DESCRIPTION
Close #65

This issue is found in this [commit](https://github.com/laneser/lab0-c/runs/5225658593?check_suite_focus=true).

After PR, the result of `make test` would be like:

![image](https://user-images.githubusercontent.com/38983968/154399085-e6ce2e17-0d73-4068-93a4-c07a52064521.png)
