### PR TITLE
Fix pre-commit hook static analysis error

### DIFF
--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -3,7 +3,9 @@
 CPPCHECK_suppresses="--inline-suppr harness.c --suppress=unmatchedSuppression:harness.c --suppress=missingIncludeSystem \
 --suppress=unusedFunction:linenoise.c --suppress=variableScope:linenoise.c \
 --suppress=nullPointerRedundantCheck:report.c \
---suppress=nullPointer:qtest.c"
+--suppress=nullPointer:qtest.c \
+--suppress=nullPointer:queue.c \
+--suppress=unmatchedSuppression:queue.c"
 CPPCHECK_OPTS="-I. --enable=all --error-exitcode=1 --force $CPPCHECK_suppresses ."
 
 RETURN=0


### PR DESCRIPTION
Suppress the nullPointer error from Cppcheck when invoking "list_entry"
from list.h. There is a \_\_typeof\_\_(((type *) 0)->member) in the
container_of macro, which is legal based on ANSI C standard but
triggers the error.