### PR TITLE
Fix memory leak in qtest.c

### DIFF
--- a/qtest.c
+++ b/qtest.c
@@ -1043,11 +1043,15 @@ int main(int argc, char *argv[])
     init_cmd();
     console_init();
 
-    /* Trigger call back function(auto completion) */
-    linenoiseSetCompletionCallback(completion);
+    /* Initialize linenoise only when infile_name not exist */
+    if (!infile_name) {
+        /* Trigger call back function(auto completion) */
+        linenoiseSetCompletionCallback(completion);
 
-    linenoiseHistorySetMaxLen(HISTORY_LEN);
-    linenoiseHistoryLoad(HISTORY_FILE); /* Load the history at startup */
+        linenoiseHistorySetMaxLen(HISTORY_LEN);
+        linenoiseHistoryLoad(HISTORY_FILE); /* Load the history at startup */
+    }
+
     set_verblevel(level);
     if (level > 1) {
         set_echo(true);
@@ -1059,7 +1063,9 @@ int main(int argc, char *argv[])
 
     bool ok = true;
     ok = ok && run_console(infile_name);
-    ok = ok && finish_cmd();
+
+    /* Do finish_cmd() before check whether ok is true or false */
+    ok = finish_cmd() && ok;
 
     return ok ? 0 : 1;
 }


### PR DESCRIPTION
I found that linenoise only work and free memory when -f is not set.
Therefore, I initialized it only when `infile_name` is NULL in qtest.c.

Besides, in original version, the finish_cmd() work when run_console() return true.
If there are something error in run_console(), it also cause memory leak.
Hence, I do finish_cmd() before check whether ok is true or false.