### PR TITLE
List size incorrect after delete middle node

### DIFF
--- a/qtest.c
+++ b/qtest.c
@@ -755,6 +755,7 @@ static bool do_dm(int argc, char *argv[])
         ok = q_delete_mid(l_meta.l);
     exception_cancel();
 
+    lcnt--;
     show_queue(3);
     return ok && !error_check();
 }


### PR DESCRIPTION
In qtest cmd mode, dm command do_dm() in qtest.c
for executing q_delete_mid() to delete middle node of list.

But there is no subtract 1 in size of list after dm command executed,
then, showing error message below:
"ERROR: Computed queue size as %d, but correct value is %d"
![bug](https://user-images.githubusercontent.com/26273380/155299746-52a55e75-1cc7-414e-bd65-a5fe8400cbf3.png)

the "correct value" amid this message
is not match to the real size of the list shows on the moniter,

this error message is caused by "lcnt", "cnt" not match in do_size(),
so, by adding a line of code in do_dm() to solve this problem.