### PR TITLE
Fix source command

### DIFF
--- a/console.c
+++ b/console.c
@@ -650,6 +650,9 @@ bool run_console(char *infile_name)
             linenoiseHistoryAdd(cmdline);       /* Add to the history. */
             linenoiseHistorySave(HISTORY_FILE); /* Save the history on disk. */
             linenoiseFree(cmdline);
+            while (buf_stack->fd != STDIN_FILENO)
+                cmd_select(0, NULL, NULL, NULL, NULL);
+            has_infile = false;
         }
     } else {
         while (!cmd_done())


### PR DESCRIPTION
The current `source` command in qtest.c is useless. It will call `do_source` function and push the file in buffer, but it never run into `cmd_select` because the program always run in linenoise while loop.