### PR TITLE
Improve pre-commit hook and readme about aspell

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Linux 20.04 or later:
 ```shell
 $ sudo apt install build-essential git clang-format cppcheck aspell colordiff valgrind
 ```
+Some distros like Arch Linux won't install `aspell-en` with `aspell`, and you must install it explicitly:
+```shell
+$ sudo pacman -S aspell-en
+```
 
 Note: [Cppcheck](http://cppcheck.sourceforge.net/) version must be at least 1.90, otherwise
 it might report errors with false positives. You can get its version by executing `$ cppcheck --version`.

--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -39,6 +39,10 @@ if [ $? -ne 0 ]; then
     echo "[!] aspell not installed. Unable to do spelling check." >&2
     exit 1
 fi
+if [ -z "$(aspell dump dicts | grep -E '^en$')" ]; then
+    echo "[!] aspell-en not installed. Unable to do spelling check." >&2
+    exit 1
+fi
 
 DIFF=$(which colordiff)
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
I add a condition in pre-commit hook to avoid commit without aspell-en installed.

Also add a notice in `README.md` for users in other distros. 

Related issue: #78 