### PR TITLE
Fix the cppcheck error

### DIFF
--- a/qtest.c
+++ b/qtest.c
@@ -494,7 +494,7 @@ static bool do_dedup(int argc, char *argv[])
     }
 
     LIST_HEAD(l_copy);
-    element_t *item, *tmp;
+    element_t *item = NULL, *tmp = NULL;
 
     // Copy l_meta.l to l_copy
     if (l_meta.l && !list_empty(l_meta.l)) {


### PR DESCRIPTION
Greetings!

The cppcheck will print the error about uninitialized variables, and then making a commit is forbidden by pre-commit hook. So, just add the initial values to them.

The cppcheck message:
```
$ cppcheck qtest.c
Checking qtest.c ...                                                                                     
qtest.c:507:33: error: Uninitialized variable: item->value [uninitvar]                                   
            slen = strlen(item->value) + 1;                                                              
                                ^                                                                        
qtest.c:504:17: note: Assuming condition is false                                                        
            if (!tmp)                                                                                    
                ^                                                                                        
qtest.c:507:33: note: Uninitialized variable: item->value                                                
            slen = strlen(item->value) + 1;                                                              
                                ^                                                                        
Checking qtest.c: LIST_POISONING...                                                                      
Checking qtest.c: __GNUC__...                                                                            
qtest.c:206:21: error: Null pointer dereference: (struct element_t*)0 [nullPointer]                      
                    list_entry(l_meta.l->next, element_t, list)->value;                                  
                    ^                                                                                    
qtest.c:295:21: error: Null pointer dereference: (struct element_t*)0 [nullPointer]                      
                    list_entry(l_meta.l->prev, element_t, list)->value;                                  
                    ^                                                                                    
qtest.c:550:20: error: Null pointer dereference: (struct element_t*)0 [nullPointer]                      
            strcmp(list_entry(item->list.next, element_t, list)->value,                                  
                   ^                                                                                     
qtest.c:557:27: error: Null pointer dereference: (struct element_t*)0 [nullPointer]                      
                   strcmp(list_entry(l_tmp, element_t, list)->value,                                     
                          ^                                                                              
qtest.c:679:20: error: Null pointer dereference: (struct element_t*)0 [nullPointer]                      
            item = list_entry(cur_l, element_t, list);                                                   
                   ^                                                                                     
qtest.c:680:25: error: Null pointer dereference: (struct element_t*)0 [nullPointer]                      
            next_item = list_entry(cur_l->next, element_t, list);                                        
                        ^                                                                                
qtest.c:778:28: error: Null pointer dereference: (struct element_t*)0 [nullPointer]                      
            element_t *e = list_entry(cur, element_t, list);                                             
                           ^                                                                             
Checking qtest.c: __aarch64__...
```