### PR TITLE
Fix the inconsistent string comparison function

### DIFF
--- a/qtest.c
+++ b/qtest.c
@@ -628,7 +628,7 @@ bool do_sort(int argc, char *argv[])
             element_t *item, *next_item;
             item = list_entry(cur_l, element_t, list);
             next_item = list_entry(cur_l->next, element_t, list);
-            if (strcasecmp(item->value, next_item->value) > 0) {
+            if (strcmp(item->value, next_item->value) > 0) {
                 report(1, "ERROR: Not sorted in ascending order");
                 ok = false;
                 break;


### PR DESCRIPTION
In the do_sort function, using the strcasecmp function to check the final list fit the requirement or not. But strcasecmp function cares about the order of a letter. So, if a list after sorted is "F d e f" error message will show. But actually it is correct order sorted by ascii code.
Replace the strcasecmp by strcmp. Strcmp(str* s1, str* s2) function compare the letter by ascii code and return >0 integer when s1's ascii code larger then s2's ascii code.