### PR TITLE
Fix pre-commit hook shell command not found error

### DIFF
--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -54,7 +54,7 @@ if [ $? -ne 0 ]; then
     SHA1SUM=shasum
 fi
 
-FILES=$(shell git diff --cached --name-only --diff-filter=ACMR | grep -E "\.(c|cpp|h)$")
+FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep -E "\.(c|cpp|h)$")
 for FILE in $FILES; do
     nf=$(git checkout-index --temp $FILE | cut -f 1)
     tempdir=$(mktemp -d) || exit 1


### PR DESCRIPTION
In line 57 of the pre-commit.hook, no "shell" is required in $( ). 
This will cause the pre-commit hook to break and print "shell: command not found".