### PR TITLE
Implement provisioning profiles for CI pipeline

### DIFF
--- a/.ci/check-provisioning.sh
+++ b/.ci/check-provisioning.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+PROVISION_DIR=lab0-c-private
+if test -f $PROVISION_DIR/queue.c; then
+    cp -f $PROVISION_DIR/queue.c .
+fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,13 +7,19 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3.3.0
+    - uses: webfactory/ssh-agent@v0.7.0
+      with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
     - name: install-dependencies
       run: |
             .ci/check-sanity.sh
             sudo apt-get update
             sudo apt-get -q -y install build-essential cppcheck
     - name: make
-      run:  make
+      run:  |
+            git clone git@github.com:sysprog21/lab0-c-private || echo "No provisioning profile found"
+            .ci/check-provisioning.sh
+            make
     - name: make check
       run: |
             make check || (cat scripts/weeping.raw ; exit 1)


### PR DESCRIPTION
Due to the lack of foreseen solutions, the official repository has been failing the CI pipeline for a lengthy long period. It raises the risk that CI will not be able to identify integration issues as soon as possible. With the help of the deploy key, this patch pulls a unique "provisioning profile" from a private repository. As a result, it is allowed to examine the official repository without potentially disclosing the solutions in forked ones.