### PR TITLE
Change prototype of q_descend

### DIFF
--- a/qtest.c
+++ b/qtest.c
@@ -747,11 +747,12 @@ static bool do_descend(int argc, char *argv[])
     error_check();
 
     if (exception_setup(true))
-        q_descend(l_meta.l);
+        lcnt = q_descend(l_meta.l);
     set_noallocate_mode(false);
 
     bool ok = true;
 
+    cnt = l_meta.size = lcnt;
     if (l_meta.size) {
         for (struct list_head *cur_l = l_meta.l->next;
              cur_l != l_meta.l && --cnt; cur_l = cur_l->next) {
@@ -759,7 +760,9 @@ static bool do_descend(int argc, char *argv[])
             item = list_entry(cur_l, element_t, list);
             next_item = list_entry(cur_l->next, element_t, list);
             if (strcmp(item->value, next_item->value) < 0) {
-                report(1, "ERROR: The queue is not in strictly greater order");
+                report(1,
+                       "ERROR: There is at least on nodes did not follow the "
+                       "ordering rule");
                 ok = false;
                 break;
             }

--- a/queue.c
+++ b/queue.c
@@ -78,7 +78,8 @@ void q_sort(struct list_head *head) {}
 
 /* Remove every node which has a node with a strictly greater value anywhere to
  * the right side of it */
-void q_descend(struct list_head *head)
+int q_descend(struct list_head *head)
 {
     // https://leetcode.com/problems/remove-nodes-from-linked-list/description/
+    return 0;
 }

--- a/queue.h
+++ b/queue.h
@@ -180,6 +180,8 @@ void q_sort(struct list_head *head);
  *
  * Reference:
  * https://leetcode.com/problems/remove-nodes-from-linked-list/description/
+ *
+ * Return: the number of elements in queue after performing operation
  */
-void q_descend(struct list_head *head);
+int q_descend(struct list_head *head);
 #endif /* LAB0_QUEUE_H */

--- a/scripts/checksums
+++ b/scripts/checksums
@@ -1,2 +1,2 @@
-e829e2b7d1a08d9f3ae84e6f2c9359fda6c1d533  queue.h
+d59f715ed1c9952b2f25d78f8a7d58f2847a3bed  queue.h
 3337dbccc33eceedda78e36cc118d5a374838ec7  list.h


### PR DESCRIPTION
This commit changes return type of q_descend from "void" to "int". The return value is regarded as the number of elements in the queue after finishing this operation. `do_descend` needs this value to traverse the list and verify the order of the queue.

The relative answer had been updated in [lab0-c-private](https://github.com/sysprog21/lab0-c-private) and passed CI. 