### PR TITLE
Provide an option to show/hide Shannon entropy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ $(GIT_HOOKS):
 
 OBJS := qtest.o report.o console.o harness.o queue.o \
         random.o dudect/constant.o dudect/fixture.o dudect/ttest.o \
+        shannon_entropy.o \
         linenoise.o web.o
 
 deps := $(OBJS:%.o=.%.o.d)

--- a/console.c
+++ b/console.c
@@ -17,6 +17,7 @@
 
 /* Some global values */
 int simulation = 0;
+int show_entropy = 0;
 static cmd_element_t *cmd_list = NULL;
 static param_element_t *param_list = NULL;
 static bool block_flag = false;
@@ -435,6 +436,7 @@ void init_cmd()
     add_param("verbose", &verblevel, "Verbosity level", NULL);
     add_param("error", &err_limit, "Number of errors until exit", NULL);
     add_param("echo", &echo, "Do/don't echo commands", NULL);
+    add_param("entropy", &show_entropy, "Show/Hide Shannon entropy", NULL);
 
     init_in();
     init_time(&last_time);

--- a/log2_lshift16.h
+++ b/log2_lshift16.h
@@ -1,0 +1,282 @@
+/*
+ * Generate precalculated values of log2 with assumption that arg will be left
+ * shifted by 16 bit and return value of log2_lshift16() will be left shifted
+ * by 3 bit All that shifts used for avoid of using floating point in
+ * calculation.
+ */
+
+#include <stdint.h>
+
+#define LOG2_ARG_SHIFT (1 << 16)
+#define LOG2_RET_SHIFT (1 << 3)
+
+/* store precalculated function (log2(arg << 24)) << 3 */
+static inline int log2_lshift16(uint64_t lshift16)
+{
+    if (lshift16 < 558) {
+        if (lshift16 < 54) {
+            if (lshift16 < 13) {
+                if (lshift16 < 7) {
+                    if (lshift16 < 1)
+                        return -136;
+                    if (lshift16 < 2)
+                        return -123;
+                    if (lshift16 < 3)
+                        return -117;
+                    if (lshift16 < 4)
+                        return -113;
+                    if (lshift16 < 5)
+                        return -110;
+                    if (lshift16 < 6)
+                        return -108;
+                    if (lshift16 < 7)
+                        return -106;
+                } else {
+                    if (lshift16 < 8)
+                        return -104;
+                    if (lshift16 < 9)
+                        return -103;
+                    if (lshift16 < 10)
+                        return -102;
+                    if (lshift16 < 11)
+                        return -100;
+                    if (lshift16 < 12)
+                        return -99;
+                    if (lshift16 < 13)
+                        return -98;
+                }
+            } else {
+                if (lshift16 < 29) {
+                    if (lshift16 < 15)
+                        return -97;
+                    if (lshift16 < 16)
+                        return -96;
+                    if (lshift16 < 17)
+                        return -95;
+                    if (lshift16 < 19)
+                        return -94;
+                    if (lshift16 < 21)
+                        return -93;
+                    if (lshift16 < 23)
+                        return -92;
+                    if (lshift16 < 25)
+                        return -91;
+                    if (lshift16 < 27)
+                        return -90;
+                    if (lshift16 < 29)
+                        return -89;
+                } else {
+                    if (lshift16 < 32)
+                        return -88;
+                    if (lshift16 < 35)
+                        return -87;
+                    if (lshift16 < 38)
+                        return -86;
+                    if (lshift16 < 41)
+                        return -85;
+                    if (lshift16 < 45)
+                        return -84;
+                    if (lshift16 < 49)
+                        return -83;
+                    if (lshift16 < 54)
+                        return -82;
+                }
+            }
+        } else {
+            if (lshift16 < 181) {
+                if (lshift16 < 99) {
+                    if (lshift16 < 59)
+                        return -81;
+                    if (lshift16 < 64)
+                        return -80;
+                    if (lshift16 < 70)
+                        return -79;
+                    if (lshift16 < 76)
+                        return -78;
+                    if (lshift16 < 83)
+                        return -77;
+                    if (lshift16 < 91)
+                        return -76;
+                    if (lshift16 < 99)
+                        return -75;
+                } else {
+                    if (lshift16 < 108)
+                        return -74;
+                    if (lshift16 < 117)
+                        return -73;
+                    if (lshift16 < 128)
+                        return -72;
+                    if (lshift16 < 140)
+                        return -71;
+                    if (lshift16 < 152)
+                        return -70;
+                    if (lshift16 < 166)
+                        return -69;
+                    if (lshift16 < 181)
+                        return -68;
+                }
+            } else {
+                if (lshift16 < 304) {
+                    if (lshift16 < 197)
+                        return -67;
+                    if (lshift16 < 215)
+                        return -66;
+                    if (lshift16 < 235)
+                        return -65;
+                    if (lshift16 < 256)
+                        return -64;
+                    if (lshift16 < 279)
+                        return -63;
+                    if (lshift16 < 304)
+                        return -62;
+                } else {
+                    if (lshift16 < 332)
+                        return -61;
+                    if (lshift16 < 362)
+                        return -60;
+                    if (lshift16 < 395)
+                        return -59;
+                    if (lshift16 < 431)
+                        return -58;
+                    if (lshift16 < 470)
+                        return -57;
+                    if (lshift16 < 512)
+                        return -56;
+                    if (lshift16 < 558)
+                        return -55;
+                }
+            }
+        }
+    } else {
+        if (lshift16 < 6317) {
+            if (lshift16 < 2048) {
+                if (lshift16 < 1117) {
+                    if (lshift16 < 609)
+                        return -54;
+                    if (lshift16 < 664)
+                        return -53;
+                    if (lshift16 < 724)
+                        return -52;
+                    if (lshift16 < 790)
+                        return -51;
+                    if (lshift16 < 861)
+                        return -50;
+                    if (lshift16 < 939)
+                        return -49;
+                    if (lshift16 < 1024)
+                        return -48;
+                    if (lshift16 < 1117)
+                        return -47;
+                } else {
+                    if (lshift16 < 1218)
+                        return -46;
+                    if (lshift16 < 1328)
+                        return -45;
+                    if (lshift16 < 1448)
+                        return -44;
+                    if (lshift16 < 1579)
+                        return -43;
+                    if (lshift16 < 1722)
+                        return -42;
+                    if (lshift16 < 1878)
+                        return -41;
+                    if (lshift16 < 2048)
+                        return -40;
+                }
+            } else {
+                if (lshift16 < 3756) {
+                    if (lshift16 < 2233)
+                        return -39;
+                    if (lshift16 < 2435)
+                        return -38;
+                    if (lshift16 < 2656)
+                        return -37;
+                    if (lshift16 < 2896)
+                        return -36;
+                    if (lshift16 < 3158)
+                        return -35;
+                    if (lshift16 < 3444)
+                        return -34;
+                    if (lshift16 < 3756)
+                        return -33;
+                } else {
+                    if (lshift16 < 4096)
+                        return -32;
+                    if (lshift16 < 4467)
+                        return -31;
+                    if (lshift16 < 4871)
+                        return -30;
+                    if (lshift16 < 5312)
+                        return -29;
+                    if (lshift16 < 5793)
+                        return -28;
+                    if (lshift16 < 6317)
+                        return -27;
+                }
+            }
+        } else {
+            if (lshift16 < 21247) {
+                if (lshift16 < 11585) {
+                    if (lshift16 < 6889)
+                        return -26;
+                    if (lshift16 < 7512)
+                        return -25;
+                    if (lshift16 < 8192)
+                        return -24;
+                    if (lshift16 < 8933)
+                        return -23;
+                    if (lshift16 < 9742)
+                        return -22;
+                    if (lshift16 < 10624)
+                        return -21;
+                    if (lshift16 < 11585)
+                        return -20;
+                } else {
+                    if (lshift16 < 12634)
+                        return -19;
+                    if (lshift16 < 13777)
+                        return -18;
+                    if (lshift16 < 15024)
+                        return -17;
+                    if (lshift16 < 16384)
+                        return -16;
+                    if (lshift16 < 17867)
+                        return -15;
+                    if (lshift16 < 19484)
+                        return -14;
+                    if (lshift16 < 21247)
+                        return -13;
+                }
+            } else {
+                if (lshift16 < 35734) {
+                    if (lshift16 < 23170)
+                        return -12;
+                    if (lshift16 < 25268)
+                        return -11;
+                    if (lshift16 < 27554)
+                        return -10;
+                    if (lshift16 < 30048)
+                        return -9;
+                    if (lshift16 < 32768)
+                        return -8;
+                    if (lshift16 < 35734)
+                        return -7;
+                } else {
+                    if (lshift16 < 38968)
+                        return -6;
+                    if (lshift16 < 42495)
+                        return -5;
+                    if (lshift16 < 46341)
+                        return -4;
+                    if (lshift16 < 50535)
+                        return -3;
+                    if (lshift16 < 55109)
+                        return -2;
+                    if (lshift16 < 60097)
+                        return -1;
+                }
+            }
+        }
+    }
+    return 0;
+}

--- a/qtest.c
+++ b/qtest.c
@@ -17,6 +17,10 @@
 #include "dudect/fixture.h"
 #include "list.h"
 
+/* Shannon entropy */
+extern double shannon_entropy(const uint8_t *input_data);
+extern int show_entropy;
+
 /* Our program needs to use regular malloc/free */
 #define INTERNAL 1
 #include "harness.h"
@@ -803,8 +807,14 @@ static bool show_queue(int vlevel)
     if (exception_setup(true)) {
         while (ok && ori != cur && cnt < lcnt) {
             element_t *e = list_entry(cur, element_t, list);
-            if (cnt < big_list_size)
+            if (cnt < big_list_size) {
                 report_noreturn(vlevel, cnt == 0 ? "%s" : " %s", e->value);
+                if (show_entropy) {
+                    report_noreturn(
+                        vlevel, "(%3.2f%%)",
+                        shannon_entropy((const uint8_t *) e->value));
+                }
+            }
             cnt++;
             cur = cur->next;
             ok = ok && !error_check();

--- a/scripts/aspell-pws
+++ b/scripts/aspell-pws
@@ -289,3 +289,4 @@ alloc
 adjtime
 perf
 uring
+Shannon

--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -3,6 +3,7 @@
 CPPCHECK_suppresses="--inline-suppr harness.c --suppress=unmatchedSuppression:harness.c --suppress=missingIncludeSystem \
 --suppress=unusedFunction:linenoise.c \
 --suppress=ConfigurationNotChecked:random.c \
+--suppress=identicalInnerCondition:log2_lshift16.h \
 --suppress=nullPointerRedundantCheck:report.c \
 --suppress=nullPointerRedundantCheck:harness.c \
 --suppress=nullPointer:qtest.c \

--- a/shannon_entropy.c
+++ b/shannon_entropy.c
@@ -1,0 +1,34 @@
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+/* Precalculated log2 realization */
+#include "log2_lshift16.h"
+
+/* Shannon full integer entropy calculation */
+#define BUCKET_SIZE (1 << 8)
+
+double shannon_entropy(const uint8_t *s)
+{
+    assert(s);
+    const uint64_t count = strlen((char *) s);
+    uint64_t entropy_sum = 0;
+    const uint64_t entropy_max = 8 * LOG2_RET_SHIFT;
+
+    uint32_t bucket[256];
+    memset(&bucket, 0, sizeof(bucket));
+
+    for (uint32_t i = 0; i < count; i++)
+        bucket[s[i]]++;
+
+    for (uint32_t i = 0; i < BUCKET_SIZE; i++) {
+        if (bucket[i]) {
+            uint64_t p = bucket[i];
+            p *= LOG2_ARG_SHIFT / count;
+            entropy_sum += -p * log2_lshift16(p);
+        }
+    }
+
+    entropy_sum /= LOG2_ARG_SHIFT;
+    return entropy_sum * 100.0 / entropy_max;
+}


### PR DESCRIPTION
The concept of information entropy was introduced by Claude Shannon in his 1948 paper "A Mathematical Theory of Communication", and is also referred to as Shannon entropy. Shannon's theory defines a data communication system composed of three elements: a source of data, a communication channel, and a receiver. The "fundamental problem of communication" – as expressed by Shannon – is for the receiver to be able to identify what data was generated by the source, based on the signal it receives through the channel.

In qtest, execute "option entropy 1" before command "show" which will display both the value of each element and its Shannon entropy.

For the sake of performance, the integer-only calculation is used for the kernel of Shannon entropy.