### PR TITLE
Add new command and associated test

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -89,3 +89,10 @@ int q_descend(struct list_head *head)
     // https://leetcode.com/problems/remove-nodes-from-linked-list/description/
     return 0;
 }
+
+/* Merge all the queues into one sorted queue, which is in ascending order */
+int q_merge(struct list_head *head)
+{
+    // https://leetcode.com/problems/merge-k-sorted-lists/
+    return 0;
+}

--- a/queue.h
+++ b/queue.h
@@ -25,6 +25,20 @@ typedef struct {
     struct list_head list;
 } element_t;
 
+/**
+ * queue_contex_t - The context managing a chain of queues
+ * @q: pointer to the head of the queue
+ * @chain: used by chaining the heads of queues
+ * @size: the length of this queue
+ * @id: the unique identification number
+ */
+typedef struct {
+    struct list_head *q;
+    struct list_head chain;
+    int size;
+    int id;
+} queue_contex_t;
+
 /* Operations on queue */
 
 /**
@@ -199,5 +213,24 @@ void q_sort(struct list_head *head);
  * Return: the number of elements in queue after performing operation
  */
 int q_descend(struct list_head *head);
+
+/**
+ * q_merge() - Merge all the queues into one sorted queue, which is in ascending
+ * order.
+ * @head: header of chain
+ *
+ * This function merge the second to the last queues in the chain into the first
+ * queue. The queues are guaranteed to be sorted before this function is called.
+ * No effect if there is only one queue in the chain. Allocation is disallowed
+ * in this function. There is no need to free the 'qcontext_t' and its member
+ * 'q' since they will be released externally. However, q_merge() is responsible
+ * for making the queues to be NULL-queue, except the first one.
+ *
+ * Reference:
+ * https://leetcode.com/problems/merge-k-sorted-lists/
+ *
+ * Return: the number of elements in queue after merging
+ */
+int q_merge(struct list_head *head);
 
 #endif /* LAB0_QUEUE_H */

--- a/scripts/checksums
+++ b/scripts/checksums
@@ -1,2 +1,2 @@
-074eed9d04bf8c7de83bab1f7cacf2ea4f9b8ae8  queue.h
+b723cead7a2d2ffb0f6cfae81fd7cde867f88d83  queue.h
 3337dbccc33eceedda78e36cc118d5a374838ec7  list.h

--- a/traces/trace-03-ops.cmd
+++ b/traces/trace-03-ops.cmd
@@ -1,24 +1,24 @@
-# Test of insert_head, insert_tail, reverse, and remove_head
+# Test of insert_head, insert_tail, remove_head, reverse and merge
 option fail 0
 option malloc 0
 new
-ih dolphin
-ih bear
-ih gerbil
+ih a
+ih r
+ih b
+sort
+new
+ih m
+ih n
+ih a
+sort
+new
+ih r
+ih c
+ih z
+sort
+merge
 reverse
-it meerkat
-it bear
-it gerbil
-reverse
-it squirrel
-reverse
-rh squirrel
-ih vulture
-reverse
-rh gerbil
-rh bear
-rh meerkat
-rh gerbil
-rh bear
-rh dolphin
-rh vulture
+rh z
+rh r
+rh r
+rh n


### PR DESCRIPTION
This commit support a new command 'merge', which merge queues into one sorted queue in ascending order. Besides, this commit forwards the declaration of 'qcontext_t' to queue.h since 'q_merge' needs to traverse the chain.

Relative test bench is added into trace-03-ops.cmd and the answer has been updated in `lab0-c-private`.