### PR TITLE
Replace ternary operator to static array indexing

### DIFF
--- a/report.c
+++ b/report.c
@@ -55,12 +55,15 @@ void report_event(message_t msg, char *fmt, ...)
 {
     va_list ap;
     bool fatal = msg == MSG_FATAL;
-    /* clang-format off */
-    char *msg_name = (msg == MSG_WARN) ? "WARNING" :
-                                         (msg == MSG_ERROR) ? "ERROR" :
-                                                              "FATAL ERROR";
-    /* clang-format on */
-    int level = msg == MSG_WARN ? 2 : msg == MSG_ERROR ? 1 : 0;
+    static const char *const msg_name_text[N_MSG] = {
+        "WARNING",
+        "ERROR",
+        "FATAL ERROR",
+    };
+    char *msg_name = msg_name_text[2];
+    if (msg < N_MSG)
+        msg_name = msg_name_text[msg];
+    int level = N_MSG - msg - 1;
     if (verblevel < level)
         return;
 

--- a/report.h
+++ b/report.h
@@ -7,7 +7,7 @@
 /* Ways to report interesting behavior and errors */
 
 /* Things to report */
-typedef enum { MSG_WARN, MSG_ERROR, MSG_FATAL } message_t;
+typedef enum { MSG_WARN, MSG_ERROR, MSG_FATAL, N_MSG } message_t;
 
 /* Buffer sizes */
 #define MAX_CHAR 512


### PR DESCRIPTION
The ternary operation has some branching overhead and is harder to extend fine-grained features in the future.
I propose to use static array indexing to select the data we need.
Furthermore, RESERVE the last element of the enum type as the size of an enum.