### PR TITLE
Mitigate false positive for measuring complexity

### DIFF
--- a/dudect/constant.c
+++ b/dudect/constant.c
@@ -67,7 +67,7 @@ void prepare_inputs(uint8_t *input_data, uint8_t *classes)
     }
 }
 
-void measure(int64_t *before_ticks,
+bool measure(int64_t *before_ticks,
              int64_t *after_ticks,
              uint8_t *input_data,
              int mode)
@@ -83,10 +83,14 @@ void measure(int64_t *before_ticks,
             dut_insert_head(
                 get_random_string(),
                 *(uint16_t *) (input_data + i * CHUNK_SIZE) % 10000);
+            int before_size = q_size(l);
             before_ticks[i] = cpucycles();
             dut_insert_head(s, 1);
             after_ticks[i] = cpucycles();
+            int after_size = q_size(l);
             dut_free();
+            if (before_size != after_size - 1)
+                return false;
         }
         break;
     case DUT(insert_tail):
@@ -96,10 +100,14 @@ void measure(int64_t *before_ticks,
             dut_insert_head(
                 get_random_string(),
                 *(uint16_t *) (input_data + i * CHUNK_SIZE) % 10000);
+            int before_size = q_size(l);
             before_ticks[i] = cpucycles();
             dut_insert_tail(s, 1);
             after_ticks[i] = cpucycles();
+            int after_size = q_size(l);
             dut_free();
+            if (before_size != after_size - 1)
+                return false;
         }
         break;
     case DUT(remove_head):
@@ -107,13 +115,17 @@ void measure(int64_t *before_ticks,
             dut_new();
             dut_insert_head(
                 get_random_string(),
-                *(uint16_t *) (input_data + i * CHUNK_SIZE) % 10000);
+                *(uint16_t *) (input_data + i * CHUNK_SIZE) % 10000 + 1);
+            int before_size = q_size(l);
             before_ticks[i] = cpucycles();
             element_t *e = q_remove_head(l, NULL, 0);
             after_ticks[i] = cpucycles();
+            int after_size = q_size(l);
             if (e)
                 q_release_element(e);
             dut_free();
+            if (before_size != after_size + 1)
+                return false;
         }
         break;
     case DUT(remove_tail):
@@ -121,13 +133,17 @@ void measure(int64_t *before_ticks,
             dut_new();
             dut_insert_head(
                 get_random_string(),
-                *(uint16_t *) (input_data + i * CHUNK_SIZE) % 10000);
+                *(uint16_t *) (input_data + i * CHUNK_SIZE) % 10000 + 1);
+            int before_size = q_size(l);
             before_ticks[i] = cpucycles();
             element_t *e = q_remove_tail(l, NULL, 0);
             after_ticks[i] = cpucycles();
+            int after_size = q_size(l);
             if (e)
                 q_release_element(e);
             dut_free();
+            if (before_size != after_size + 1)
+                return false;
         }
         break;
     default:
@@ -142,4 +158,5 @@ void measure(int64_t *before_ticks,
             dut_free();
         }
     }
+    return true;
 }

--- a/dudect/constant.h
+++ b/dudect/constant.h
@@ -1,6 +1,7 @@
 #ifndef DUDECT_CONSTANT_H
 #define DUDECT_CONSTANT_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 /* Number of measurements per test */
@@ -27,7 +28,7 @@ enum {
 
 void init_dut();
 void prepare_inputs(uint8_t *input_data, uint8_t *classes);
-void measure(int64_t *before_ticks,
+bool measure(int64_t *before_ticks,
              int64_t *after_ticks,
              uint8_t *input_data,
              int mode);

--- a/dudect/fixture.c
+++ b/dudect/fixture.c
@@ -131,10 +131,10 @@ static bool doit(int mode)
 
     prepare_inputs(input_data, classes);
 
-    measure(before_ticks, after_ticks, input_data, mode);
+    bool ret = measure(before_ticks, after_ticks, input_data, mode);
     differentiate(exec_times, before_ticks, after_ticks);
     update_statistics(exec_times, classes);
-    bool ret = report();
+    ret &= report();
 
     free(before_ticks);
     free(after_ticks);
@@ -170,11 +170,8 @@ static bool test_const(char *text, int mode)
     return result;
 }
 
-#define DUT_FUNC_IMPL(op)                \
-    bool is_##op##_const(void)           \
-    {                                    \
-        return test_const(#op, DUT(op)); \
-    }
+#define DUT_FUNC_IMPL(op) \
+    bool is_##op##_const(void) { return test_const(#op, DUT(op)); }
 
 #define _(x) DUT_FUNC_IMPL(x)
 DUT_FUNCS

--- a/qtest.c
+++ b/qtest.c
@@ -182,7 +182,8 @@ static bool do_ih(int argc, char *argv[])
         }
         bool ok = is_insert_head_const();
         if (!ok) {
-            report(1, "ERROR: Probably not constant time");
+            report(1,
+                   "ERROR: Probably not constant time or wrong implementation");
             return false;
         }
         report(1, "Probably constant time");
@@ -271,7 +272,8 @@ static bool do_it(int argc, char *argv[])
         }
         bool ok = is_insert_tail_const();
         if (!ok) {
-            report(1, "ERROR: Probably not constant time");
+            report(1,
+                   "ERROR: Probably not constant time or wrong implementation");
             return false;
         }
         report(1, "Probably constant time");
@@ -351,7 +353,8 @@ static bool do_remove(int option, int argc, char *argv[])
         }
         bool ok = option ? is_remove_tail_const() : is_remove_head_const();
         if (!ok) {
-            report(1, "ERROR: Probably not constant time");
+            report(1,
+                   "ERROR: Probably not constant time or wrong implementation");
             return false;
         }
         report(1, "Probably constant time");


### PR DESCRIPTION
Before this commit, we found that the wrong implementation of 'ih', 'it', 'rh', 'rt' still pass trace-17. This commit consolidate the test by verifying both the correctness and time complexity.