### PR TITLE
Fix a mistake in q_swap()'s comment

### DIFF
--- a/queue.h
+++ b/queue.h
@@ -156,7 +156,7 @@ bool q_delete_mid(struct list_head *head);
 bool q_delete_dup(struct list_head *head);
 
 /**
- * q_delete_dup() - Swap every two adjacent nodes
+ * q_swap() - Swap every two adjacent nodes
  * @head: header of queue
  *
  * Reference:


### PR DESCRIPTION
Correct "q_delete_dup()" in q_swap()'s comment.