### PR TITLE
Suppress Cppcheck

### DIFF
--- a/report.c
+++ b/report.c
@@ -55,6 +55,7 @@ void report_event(message_t msg, char *fmt, ...)
 {
     va_list ap;
     bool fatal = msg == MSG_FATAL;
+    // cppcheck-suppress constVariable
     static char *msg_name_text[N_MSG] = {
         "WARNING",
         "ERROR",


### PR DESCRIPTION
With Cppcheck 2.7, it will report below error:
    report.c:59:18: style: Variable   'msg_name_text' can be declared with const [constVariable]
    static char *msg_name_text[N_MSG] = {
Add inline suppression to suppress warning.