### PR TITLE
Make SSH_PRIVATE_KEY optional

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3.3.0
     - uses: webfactory/ssh-agent@v0.7.0
+      continue-on-error: true
       with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
     - name: install-dependencies


### PR DESCRIPTION
The GitHub Action run on the fork of the original repository will not work
because the secret SSH_PRIVATE_KEY will not be set in the forked repository.

Make the step 'webfactory/ssh-agent@v0.7.0' optional to solve the problem.