### PR TITLE
Fix segfault while doing reverse K on NULL queue

### DIFF
--- a/qtest.c
+++ b/qtest.c
@@ -775,7 +775,7 @@ static bool do_reverseK(int argc, char *argv[])
     }
 
     set_noallocate_mode(true);
-    if (exception_setup(true))
+    if (current && exception_setup(true))
         q_reverseK(current->q, k);
     exception_cancel();
 


### PR DESCRIPTION
In `do_reverseK`, we should check whether `current` is NULL before dereferencing `current`. We should not dereference it if it is NULL.