### PR TITLE
Fix queue error when delete middle node

### DIFF
--- a/qtest.c
+++ b/qtest.c
@@ -686,7 +686,11 @@ static bool do_dm(int argc, char *argv[])
         ok = q_delete_mid(current->q);
     exception_cancel();
 
-    current->size--;
+    if (!current->size)
+        report(3, "Warning: Try to delete middle node to empty queue");
+
+    if (current->size)
+        --current->size;
     q_show(3);
     return ok && !error_check();
 }


### PR DESCRIPTION
When queue is empty, calling `do_dm()` causes "current->size" less than 0.

* error message:
```
$ ./qtest 
cmd> new
l = []
cmd> size
Queue size = 0
l = []
cmd> dm
l = []
cmd> size
ERROR: Computed queue size as 0, but correct value is -1
l = []
cmd> 
```

After patch:
```
$ ./qtest 
cmd> new
l = []
cmd> size
Queue size = 0
l = []
cmd> dm
Warning: Try to delete middle node to empty queue
l = []
cmd> size
Queue size = 0
l = []
```