### PR TITLE
Remove `return true;` in `q_quit` function

### DIFF
--- a/qtest.c
+++ b/qtest.c
@@ -1059,7 +1059,6 @@ static void q_init()
 
 static bool q_quit(int argc, char *argv[])
 {
-    return true;
     report(3, "Freeing queue");
     if (current && current->size > BIG_LIST_SIZE)
         set_cautious_mode(false);


### PR DESCRIPTION
`return true;` in the beginning of `q_quit` blocks freeing the queues when the program exits. Therefore, it should be removed.