### PR TITLE
Register `line_atexit` in `linenoise` function

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -243,10 +243,6 @@ static int enable_raw_mode(int fd)
 {
     if (!isatty(STDIN_FILENO))
         goto fatal;
-    if (!atexit_registered) {
-        atexit(line_atexit);
-        atexit_registered = true;
-    }
     if (tcgetattr(fd, &orig_termios) == -1)
         goto fatal;
 
@@ -1188,6 +1184,11 @@ static char *line_no_tty(void)
 char *linenoise(const char *prompt)
 {
     char buf[LINENOISE_MAX_LINE];
+
+    if (!atexit_registered) {
+        atexit(line_atexit);
+        atexit_registered = true;
+    }
 
     if (!isatty(STDIN_FILENO)) {
         /* Not a tty: read from file / pipe. In this mode we don't want any


### PR DESCRIPTION
Before this change, `line_atexit` is registered in `enable_raw_mode`. However, if stdin is not a tty, (eg. it may be a file), `enable_raw_mode` will not be called and `line_atexit` will not be registered.

In this case, if we use valgrind to detect memory leak, the history will not be freed if stdin is not a tty. (eg. using trace files as stdin)

This commit fixes this problem. It make sure that `line_atexit` is registered when linenoise is used.