### PR TITLE
Add option "descend" to qtest

### DIFF
--- a/qtest.c
+++ b/qtest.c
@@ -73,6 +73,8 @@ static int fail_count = 0;
 
 static int string_length = MAXSTRING;
 
+static int descend = 0;
+
 #define MIN_RANDSTR_LEN 5
 #define MAX_RANDSTR_LEN 10
 static const char charset[] = "abcdefghijklmnopqrstuvwxyz";
@@ -598,7 +600,7 @@ bool do_sort(int argc, char *argv[])
 
     set_noallocate_mode(true);
     if (current && exception_setup(true))
-        q_sort(current->q);
+        q_sort(current->q, descend);
     exception_cancel();
     set_noallocate_mode(false);
 
@@ -606,13 +608,18 @@ bool do_sort(int argc, char *argv[])
     if (current && current->size) {
         for (struct list_head *cur_l = current->q->next;
              cur_l != current->q && --cnt; cur_l = cur_l->next) {
-            /* Ensure each element in ascending order */
-            /* FIXME: add an option to specify sorting order */
+            /* Ensure each element in ascending/descending order */
             element_t *item, *next_item;
             item = list_entry(cur_l, element_t, list);
             next_item = list_entry(cur_l->next, element_t, list);
-            if (strcmp(item->value, next_item->value) > 0) {
+            if (!descend && strcmp(item->value, next_item->value) > 0) {
                 report(1, "ERROR: Not sorted in ascending order");
+                ok = false;
+                break;
+            }
+
+            if (descend && strcmp(item->value, next_item->value) < 0) {
+                report(1, "ERROR: Not sorted in descending order");
                 ok = false;
                 break;
             }
@@ -672,6 +679,54 @@ static bool do_swap(int argc, char *argv[])
 
     q_show(3);
     return !error_check();
+}
+
+
+static bool do_ascend(int argc, char *argv[])
+{
+    if (argc != 1) {
+        report(1, "%s takes too much arguments", argv[0]);
+        return false;
+    }
+
+    if (!current || !current->q) {
+        report(3, "Warning: Calling ascend on null queue");
+        return false;
+    }
+    error_check();
+
+
+    int cnt = q_size(current->q);
+    if (!cnt)
+        report(3, "Warning: Calling ascend on empty queue");
+    else if (cnt < 2)
+        report(3, "Warning: Calling ascend on single node");
+    error_check();
+
+    if (exception_setup(true))
+        current->size = q_ascend(current->q);
+    set_noallocate_mode(false);
+
+    bool ok = true;
+
+    cnt = current->size;
+    if (current->size) {
+        for (struct list_head *cur_l = current->q->next;
+             cur_l != current->q && --cnt; cur_l = cur_l->next) {
+            element_t *item, *next_item;
+            item = list_entry(cur_l, element_t, list);
+            next_item = list_entry(cur_l->next, element_t, list);
+            if (strcmp(item->value, next_item->value) > 0) {
+                report(1,
+                       "ERROR: At least one node violated the ordering rule");
+                ok = false;
+                break;
+            }
+        }
+    }
+
+    q_show(3);
+    return ok && !error_check();
 }
 
 static bool do_descend(int argc, char *argv[])
@@ -767,7 +822,7 @@ static bool do_merge(int argc, char *argv[])
     int len = 0;
     set_noallocate_mode(true);
     if (current && exception_setup(true))
-        len = q_merge(&chain.head);
+        len = q_merge(&chain.head, descend);
     exception_cancel();
     set_noallocate_mode(false);
 
@@ -796,11 +851,22 @@ static bool do_merge(int argc, char *argv[])
             element_t *item, *next_item;
             item = list_entry(cur_l, element_t, list);
             next_item = list_entry(cur_l->next, element_t, list);
-            if (strcmp(item->value, next_item->value) > 0) {
+            if (!descend && strcmp(item->value, next_item->value) > 0) {
                 report(1,
                        "ERROR: Not sorted in ascending order (It might because "
                        "of unsorted queues are merged or there're some flaws "
                        "in 'q_merge')");
+                ok = false;
+                break;
+            }
+
+
+            if (descend && strcmp(item->value, next_item->value) < 0) {
+                report(
+                    1,
+                    "ERROR: Not sorted in descending order (It might because "
+                    "of unsorted queues are merged or there're some flaws "
+                    "in 'q_merge')");
                 ok = false;
                 break;
             }
@@ -971,13 +1037,17 @@ static void console_init()
         "Remove from tail of queue. Optionally compare to expected value str",
         "[str]");
     ADD_COMMAND(reverse, "Reverse queue", "");
-    ADD_COMMAND(sort, "Sort queue in ascending order", "");
+    ADD_COMMAND(sort, "Sort queue in ascending/descening order", "");
     ADD_COMMAND(size, "Compute queue size n times (default: n == 1)", "[n]");
     ADD_COMMAND(show, "Show queue contents", "");
     ADD_COMMAND(dm, "Delete middle node in queue", "");
     ADD_COMMAND(dedup, "Delete all nodes that have duplicate string", "");
     ADD_COMMAND(merge, "Merge all the queues into one sorted queue", "");
     ADD_COMMAND(swap, "Swap every two adjacent nodes in queue", "");
+    ADD_COMMAND(ascend,
+                "Remove every node which has a node with a strictly greater "
+                "value anywhere to the right side of it",
+                "");
     ADD_COMMAND(descend,
                 "Remove every node which has a node with a strictly greater "
                 "value anywhere to the right side of it",
@@ -990,6 +1060,8 @@ static void console_init()
               NULL);
     add_param("fail", &fail_limit,
               "Number of times allow queue operations to return false", NULL);
+    add_param("descend", &descend,
+              "Sort and merge queue in ascending/descending order", NULL);
 }
 
 /* Signal handlers */

--- a/queue.c
+++ b/queue.c
@@ -79,8 +79,16 @@ void q_reverseK(struct list_head *head, int k)
     // https://leetcode.com/problems/reverse-nodes-in-k-group/
 }
 
-/* Sort elements of queue in ascending order */
-void q_sort(struct list_head *head) {}
+/* Sort elements of queue in ascending/descending order */
+void q_sort(struct list_head *head, bool descend) {}
+
+/* Remove every node which has a node with a strictly less value anywhere to
+ * the right side of it */
+int q_ascend(struct list_head *head)
+{
+    // https://leetcode.com/problems/remove-nodes-from-linked-list/
+    return 0;
+}
 
 /* Remove every node which has a node with a strictly greater value anywhere to
  * the right side of it */
@@ -90,8 +98,9 @@ int q_descend(struct list_head *head)
     return 0;
 }
 
-/* Merge all the queues into one sorted queue, which is in ascending order */
-int q_merge(struct list_head *head)
+/* Merge all the queues into one sorted queue, which is in ascending/descending
+ * order */
+int q_merge(struct list_head *head, bool descend)
 {
     // https://leetcode.com/problems/merge-k-sorted-lists/
     return 0;

--- a/queue.h
+++ b/queue.h
@@ -191,13 +191,29 @@ void q_reverse(struct list_head *head);
 void q_reverseK(struct list_head *head, int k);
 
 /**
- * q_sort() - Sort elements of queue in ascending order
+ * q_sort() - Sort elements of queue in ascending/descending order
  * @head: header of queue
+ * @descend: whether or not to sort in descending order
  *
  * No effect if queue is NULL or empty. If there has only one element, do
  * nothing.
  */
-void q_sort(struct list_head *head);
+void q_sort(struct list_head *head, bool descend);
+
+/**
+ * q_ascend() - Remove every node which has a node with a strictly less
+ * value anywhere to the right side of it.
+ * @head: header of queue
+ *
+ * No effect if queue is NULL or empty. If there has only one element, do
+ * nothing.
+ *
+ * Reference:
+ * https://leetcode.com/problems/remove-nodes-from-linked-list/
+ *
+ * Return: the number of elements in queue after performing operation
+ */
+int q_ascend(struct list_head *head);
 
 /**
  * q_descend() - Remove every node which has a node with a strictly greater
@@ -215,9 +231,10 @@ void q_sort(struct list_head *head);
 int q_descend(struct list_head *head);
 
 /**
- * q_merge() - Merge all the queues into one sorted queue, which is in ascending
- * order.
+ * q_merge() - Merge all the queues into one sorted queue, which is in
+ * ascending/descending order.
  * @head: header of chain
+ * @descend: whether to merge queues sorted in descending order
  *
  * This function merge the second to the last queues in the chain into the first
  * queue. The queues are guaranteed to be sorted before this function is called.
@@ -231,6 +248,6 @@ int q_descend(struct list_head *head);
  *
  * Return: the number of elements in queue after merging
  */
-int q_merge(struct list_head *head);
+int q_merge(struct list_head *head, bool descend);
 
 #endif /* LAB0_QUEUE_H */

--- a/scripts/checksums
+++ b/scripts/checksums
@@ -1,2 +1,2 @@
-0690973a922f166c7da4957c2c884c1ff80501c0  queue.h
+fc83d2142cdebd29bf8dbf01d2c21c59f8c6a7ce  queue.h
 3337dbccc33eceedda78e36cc118d5a374838ec7  list.h


### PR DESCRIPTION
Add an additional option "descend" to qtest. It controls whether "sort" and "merge" command treat queues in descending order. Furthermore, this commit provides a new command "ascend" to eliminate every node which has one or more nodes with greater value at the right side of it in queue.