### PR TITLE
Delete the ignore file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,4 +80,7 @@ clean:
 	rm -rf *.dSYM
 	(cd traces; rm -f *~)
 
+distclean: clean
+	rm -f .cmd_history
+
 -include $(deps)


### PR DESCRIPTION
After input the command like `new`, the file `.cmd_history` is generated. However, when input the command `make clean`, it is still exist. Hence, it should be deleted.