### PR TITLE
Change CHUNK_SIZE to 2

### DIFF
--- a/dudect/constant.h
+++ b/dudect/constant.h
@@ -8,7 +8,7 @@
 #define N_MEASURES 150
 
 /* Allow random number range from 0 to 65535 */
-#define CHUNK_SIZE 16
+#define CHUNK_SIZE 2
 
 #define DROP_SIZE 20
 


### PR DESCRIPTION
`CHUNK_SIZE` should be 2 because the random number ranging from 0 to 65535 takes 16 bits, which is 2 bytes.