### PR TITLE
Fix duplicate item detection issue

### DIFF
--- a/qtest.c
+++ b/qtest.c
@@ -475,7 +475,6 @@ static bool do_dedup(int argc, char *argv[])
     }
 
     struct list_head *l_tmp = current->q->next;
-    bool is_this_dup = false;
     // Compare between new list and old one
     list_for_each_entry (item, &l_copy, list) {
         // Skip comparison with new list if the string is duplicate
@@ -483,7 +482,7 @@ static bool do_dedup(int argc, char *argv[])
             item->list.next != &l_copy &&
             strcmp(list_entry(item->list.next, element_t, list)->value,
                    item->value) == 0;
-        if (is_this_dup || is_next_dup) {
+        if (is_next_dup) {
             // Update list size
             current->size--;
         } else if (l_tmp != current->q &&
@@ -492,7 +491,6 @@ static bool do_dedup(int argc, char *argv[])
             l_tmp = l_tmp->next;
         else
             ok = false;
-        is_this_dup = is_next_dup;
     }
     // All elements in new list should be traversed
     ok = ok && l_tmp == current->q;


### PR DESCRIPTION
Remove the 'is_this_dup' from qtest.c's delete duplicate implementation.

Previously, 'is_this_dup' was used to indicate if the current item in the old list was a duplicate of the previous item, while 'is_next_dup' indicated if the current item was a duplicate of the next item.

This led to comparisons always skipping when (is_next_dup || is_this_dup) was true, resulting in the item with duplicates not being compared with items in the new list.

The 'is_next_dup' is retained for accurate comparison.