### PR TITLE
Fix pre-push.hook validation bug

### DIFF
--- a/scripts/pre-push.hook
+++ b/scripts/pre-push.hook
@@ -12,7 +12,7 @@ NC='\033[0m' # No Color
 # Author: Jim Huang <jserv@ccns.ncku.edu.tw>
 # Date:   Tue Feb 20 03:59:49 2024 +0800
 #     Bump copyright year
-commit=$(git rev-list -n 1 --grep '^Bump copyright' 1aca5b98471765db50c91e03298e49bf7c08cdbc...HEAD)
+commit=$(git rev-list --skip 1 --grep '^Bump copyright' 1aca5b98471765db50c91e03298e49bf7c08cdbc...HEAD)
 if [ x"$commit" != x"3ed17237af5b1ead6c394df5099bc2bc1f8392df" ] ; then
     echo -e "${RED}ERROR${NC}: This repository is insane."
     echo -e "Make sure you did fork from https://github.com/sysprog21/lab0-c recently."


### PR DESCRIPTION
## Summary
We utilize ./scripts/pre-push.hook to do the checking when trying to do `git push`. One of the stages is to check a speicific commit hash number for validation of the repository.

It tries to get the hash number of commit `3ed17237af5b1ead6c394df5099bc2bc1f8392df`, using a filter to get the value of `commit` whose git log message matches the pattern specified in line 15 of `/scripts/pre-push.hook`.

However when merging the commit into the master branch, it generated a new commit which is `390ade9eca44b432acb758084e7122cc2c46e485`, so the value of `commit` in line 15 of `/scripts/pre-push.hook` will be incorrect.

That's why we modify a small part of the command in line 15 from `-n 1` to `--skip 1`, so we can neglect the merging commit and get the actual commit hash number we want.

## Fixed Issue
Fixed #151 