### PR TITLE
Suppress Cppcheck constant check

### DIFF
--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -16,7 +16,8 @@ CPPCHECK_suppresses="--inline-suppr harness.c \
 --suppress=nullPointer:qtest.c \
 --suppress=returnDanglingLifetime:report.c \
 --suppress=constParameterCallback:console.c \
---suppress=constParameterPointer:console.c"
+--suppress=constParameterPointer:console.c \
+--suppress=checkLevelNormal:log2_lshift16.h"
 CPPCHECK_OPTS="-I. --enable=all --error-exitcode=1 --force $CPPCHECK_suppresses $CPPCHECK_unmatched ."
 
 RETURN=0


### PR DESCRIPTION
Refine the pre-commit hook to enforce a minimum Cppcheck Version of 1.90, alerting users with an error message and guidance on compiling Cppcheck from source if their version is outdated.

Additionally, upgrade the hook to include the
"--check-level=exhaustive" option for Cppcheck versions 2.11 and above, ensuring a comprehensive analysis.
This adjustment caters to the enhanced capabilities available from version 2.11, promoting more detailed code quality checks.

Eliminate the "--check-level=" is needed after 2.11.
#153 