### PR TITLE
Add q_new function for creating a new linked list

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -14,6 +14,11 @@
 /* Create an empty queue */
 struct list_head *q_new()
 {
+    struct list_head *head = malloc(sizeof(struct list_head));
+    if (head) {
+        INIT_LIST_HEAD(head);
+        return head;
+    }
     return NULL;
 }
 


### PR DESCRIPTION
Create a q_new function to dynamically allocate memory for a new struct list_head and initialize it using INIT_LIST_HEAD macro. The 'q_new' function returns the pointer to the newly created linked list head. If memory allocation fails, it returns NULL.