### PR TITLE
Correct function parameter to match implementation

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -18,7 +18,7 @@ struct list_head *q_new()
 }
 
 /* Free all storage used by queue */
-void q_free(struct list_head *l) {}
+void q_free(struct list_head *head) {}
 
 /* Insert an element at head of queue */
 bool q_insert_head(struct list_head *head, char *s)


### PR DESCRIPTION
This commit ensures that the parameters of the q_free function in 'queue.h' match those in 'queue.c'.