### PR TITLE
Integrate linenoise with web server

### DIFF
--- a/linenoise.h
+++ b/linenoise.h
@@ -54,9 +54,11 @@ typedef struct {
 typedef void(line_completion_callback_t)(const char *, line_completions_t *);
 typedef char *(line_hints_callback_t)(const char *, int *color, int *bold);
 typedef void(line_free_hints_callback_t)(void *);
+typedef int(line_eventmux_callback_t)(char *);
 void line_set_completion_callback(line_completion_callback_t *);
 void line_set_hints_callback(line_hints_callback_t *);
 void line_set_free_hints_callback(line_free_hints_callback_t *);
+void line_set_eventmux_callback(line_eventmux_callback_t *);
 void line_add_completion(line_completions_t *, const char *);
 /* clang-format on */
 

--- a/web.h
+++ b/web.h
@@ -9,4 +9,6 @@ char *web_recv(int fd, struct sockaddr_in *clientaddr);
 
 void web_send(int out_fd, char *buffer);
 
+int web_eventmux(char *buf);
+
 #endif


### PR DESCRIPTION
## Summary

In the previous version of console implementation, we tried to integrate tiny-web-server to enable the ability of processing commands from web requests. As the result, the package linenoise which is responsible for
command-line auto-complete needs to be disabled during the running time of tiny-web-server. Because the `line_edit()` function in linenoise.c doesn't have the ability to handle web requests correctly.

When we start the web server, we use `cmd_select` in console.c and use `select` system call to monitor web socket file descriptor and stdin_fd at the same time, however, this ability should present in the `line_edit` function in linenoise.c so we can process commands from command-line and from web requests at the same time.

That's the reason I re-design the linenoise implementation and make some modification to put `select()` system call in `line_edit` so we can have the full ability to use web server and linenoise package in command-line at the same time.