### PR TITLE
Suppress Cppcheck checking level

### DIFF
--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -5,6 +5,8 @@ for f in *.c; do
     CPPCHECK_unmatched="$CPPCHECK_unmatched --suppress=unmatchedSuppression:$f"
 done
 
+# We suppress the checkLevelNormal warning for Cppcheck versions 2.11 and above.
+# Please refer to issues/153 for more details.
 CPPCHECK_suppresses="--inline-suppr harness.c \
 --suppress=missingIncludeSystem \
 --suppress=noValidConfiguration \


### PR DESCRIPTION
Refine the pre-commit hook to enforce a minimum Cppcheck version of 1.90, alerting users with an error message and providing guidance on compiling Cppcheck from the source if their version is outdated.

Additionally, upgrade the hook for "--check-level=exhaustive" option against Cppcheck versions 2.11 and above, ensuring a comprehensive analysis. This adjustment leverages the enhanced capabilities available from version 2.11, promoting more detailed code quality checks.

This commit is aiming to fix commit #[3aa0d55](https://github.com/sysprog21/lab0-c/commit/3aa0d557fddd5fdd3ae5afb34f73a5c7be463e3c) 's misinformed title. We just add comments to explain why this changes.