### PR TITLE
Remove unused variable and fix command prompt display issue 

### DIFF
--- a/console.c
+++ b/console.c
@@ -586,6 +586,7 @@ static int cmd_select(int nfds,
                 interpret_cmd(cmdline);
             fflush(stdout);
         } else {
+            set_echo(0);
             char *cmdline = readline();
             if (cmdline)
                 interpret_cmd(cmdline);

--- a/console.c
+++ b/console.c
@@ -21,7 +21,6 @@ int show_entropy = 0;
 static cmd_element_t *cmd_list = NULL;
 static param_element_t *param_list = NULL;
 static bool block_flag = false;
-static bool prompt_flag = true;
 
 /* Am I timing a command that has the console blocked? */
 static bool block_timing = false;
@@ -581,13 +580,12 @@ static int cmd_select(int nfds,
         if (web_fd != -1)
             FD_SET(web_fd, readfds);
 
-        if (infd == STDIN_FILENO && prompt_flag) {
+        if (infd == STDIN_FILENO) {
             char *cmdline = linenoise(prompt);
             if (cmdline)
                 interpret_cmd(cmdline);
             fflush(stdout);
-            prompt_flag = true;
-        } else if (infd != STDIN_FILENO) {
+        } else {
             char *cmdline = readline();
             if (cmdline)
                 interpret_cmd(cmdline);


### PR DESCRIPTION
Commit ("Remove unused variable") removes an unused variable in `console.c`. `prompt_flag` in `console.c` is specified as static and the only usage is the if statement at line 583 and the only assignment to it is at line 588 which assigns 1 to `prompt_flag`. Since no other code can modify this variable, it can be removed.

Commit ("Fix command prompt showing when using file input") fixes command prompt display issue when using file as input. Commit [b13335b](https://github.com/sysprog21/lab0-c/commit/b13335b841d9fc482f532f441d64e7729594d204) ("Introduce eventmux callback function for linenoise") removes `set_echo(0)` when `infd` is not the standard input, which will show command prompt while executing command from input files. Adding it back fixes the issue.