### PR TITLE
Introduce test_calloc and alloc

### DIFF
--- a/harness.h
+++ b/harness.h
@@ -55,6 +55,7 @@ void trigger_exception(char *msg);
 
 /* Tested program use our versions of malloc and free */
 #define malloc test_malloc
+#define calloc test_calloc
 #define free test_free
 
 /* Use undef to avoid strdup redefined error */


### PR DESCRIPTION
This commit introduces a generic alloc function to handle both test_malloc and test_calloc operations based on the provided alloc_func_t. Additionally, it implements the test_calloc function to allocate memory and initialize it to zero.