### PR TITLE
Improve string randomness

### DIFF
--- a/qtest.c
+++ b/qtest.c
@@ -172,9 +172,11 @@ static void fill_rand_string(char *buf, size_t buf_size)
     while (len < MIN_RANDSTR_LEN)
         len = rand() % buf_size;
 
-    randombytes((uint8_t *) buf, len);
+    uint64_t randstr_buf_64[MAX_RANDSTR_LEN] = {0};
+    randombytes((uint8_t *) randstr_buf_64, len * sizeof(uint64_t));
     for (size_t n = 0; n < len; n++)
-        buf[n] = charset[buf[n] % (sizeof(charset) - 1)];
+        buf[n] = charset[randstr_buf_64[n] % (sizeof(charset) - 1)];
+
     buf[len] = '\0';
 }
 


### PR DESCRIPTION
### Problem

Current implementation of function fill_rand_string uses randombytes() to get random bytes and then get modulus of 26. However, since the number of variations is 256, which is not exact division of 26, and this causes the last four characters 'w', 'x', 'y', and 'z' appearing with less frequency than other characters. By testing with the script https://github.com/wuyihung/lab0-c/blob/master/scripts/test_prng.py, it is found that the entropy and arithmetic mean slightly deviates from the theoretical values:
| PRNG | Theoretical | Current |
| -| - | - |
| Entropy (bits per byte)  | 4.700440 | 4.699504 |
| Arithmetic mean | 109.5 | 109.3771 |

### Solution

We expand buffer to 64-bit unsigned integer before getting random bytes. Calculating modulus on 64-bit unsigned integer gives more random result.

### Verification

After implementation, the entropy and arithmetic mean improves to be closer to theoretical values:
| PRNG | Theoretical | After implementation |
| -| - | - |
| Entropy (bits per byte)  | 4.700440 | 4.700423 |
| Arithmetic mean | 109.5 | 109.5105 |