### PR TITLE
Fix description of `q_delete_dup`

### DIFF
--- a/queue.h
+++ b/queue.h
@@ -151,7 +151,7 @@ bool q_delete_mid(struct list_head *head);
  * Reference:
  * https://leetcode.com/problems/remove-duplicates-from-sorted-list-ii/
  *
- * Return: true for success, false if list is NULL.
+ * Return: true for success, false if list is NULL or empty.
  */
 bool q_delete_dup(struct list_head *head);
 

--- a/scripts/checksums
+++ b/scripts/checksums
@@ -1,2 +1,2 @@
-444bab14cb8ad4c949f61b3c10a22a3ed2401425  queue.h
+186d420b53e21c6daf8eabe980a5b90780c53bcd  queue.h
 3337dbccc33eceedda78e36cc118d5a374838ec7  list.h


### PR DESCRIPTION
The originally document says `false` is returned when `head` is `NULL`, which is inconsistent with functions like `q_delete_mid` and is confirmed to be a typo.