### PR TITLE
Prevent is_circular function from infinite loop

### DIFF
--- a/qtest.c
+++ b/qtest.c
@@ -880,17 +880,23 @@ static bool do_merge(int argc, char *argv[])
 static bool is_circular()
 {
     struct list_head *cur = current->q->next;
+    struct list_head *fast = (cur) ? cur->next : NULL;
     while (cur != current->q) {
-        if (!cur)
+        if (!cur || !fast || !(fast->next))
+            return false;
+        if (cur == fast)
             return false;
         cur = cur->next;
+        fast = fast->next->next;
     }
 
     cur = current->q->prev;
+    fast = (cur) ? cur->prev : NULL;
     while (cur != current->q) {
-        if (!cur)
+        if (!cur || !fast || !(fast->prev))
             return false;
         cur = cur->prev;
+        fast = fast->prev->prev;
     }
     return true;
 }

--- a/qtest.c
+++ b/qtest.c
@@ -882,7 +882,7 @@ static bool is_circular()
     struct list_head *cur = current->q->next;
     struct list_head *fast = (cur) ? cur->next : NULL;
     while (cur != current->q) {
-        if (!cur || !fast || !(fast->next))
+        if (!cur || !fast || !fast->next)
             return false;
         if (cur == fast)
             return false;
@@ -893,7 +893,7 @@ static bool is_circular()
     cur = current->q->prev;
     fast = (cur) ? cur->prev : NULL;
     while (cur != current->q) {
-        if (!cur || !fast || !(fast->prev))
+        if (!cur || !fast || !fast->prev)
             return false;
         cur = cur->prev;
         fast = fast->prev->prev;


### PR DESCRIPTION
Original function will face infinite loop when there is a mid-list loop in queue. Transform the is_circular function by shifting from a single pointer approach to employing slow and fast pointers. The single pointer method falls short in detecting loops that occur mid-list without additional storage. Utilizing slow and fast pointers overcomes this limitation, enabling the detection of mid-list loops. Although this approach introduces a slight increase in conditional checks, it remains a superior method for loop detection without the need for extra storage.