### PR TITLE
Enforce the use of Change-Id in each commit

### DIFF
--- a/scripts/aspell-pws
+++ b/scripts/aspell-pws
@@ -295,3 +295,6 @@ Shannon
 http
 https
 tcp
+awk
+sed
+changeid

--- a/scripts/commit-msg.hook
+++ b/scripts/commit-msg.hook
@@ -280,6 +280,163 @@ validate_commit_message() {
   test $? -eq 1 || add_warning 1 "Do not start the subject line with whitespace"
 }
 
+unset GREP_OPTIONS
+
+CHANGE_ID_AFTER="Bug|Issue|Test"
+MSG="$1"
+
+# Ensure that a unique Change-Id is present, and generate one if it is not.
+#
+# Partially taken from Gerrit Code Review 3.3.0-56-gbcecc47463
+add_change_id() {
+  clean_message=`sed -e '
+    /^diff --git .*/{
+      s///
+      q
+    }
+    /^Signed-off-by:/d
+    /^#/d
+  ' "$MSG" | git stripspace`
+  if test -z "$clean_message"
+  then
+    return
+  fi
+
+  # Does Change-Id: already exist? if so, exit (no change).
+  if grep -i '^Change-Id:' "$MSG" >/dev/null
+  then
+    return
+  fi
+
+  id=`_gen_changeid`
+  T="$MSG.tmp.$$"
+  AWK=awk
+
+  # Get core.commentChar from git config or use default symbol
+  commentChar=`git config --get core.commentChar`
+  commentChar=${commentChar:-#}
+
+  # How this works:
+  # - parse the commit message as (textLine+ blankLine*)*
+  # - assume textLine+ to be a footer until proven otherwise
+  # - exception: the first block is not footer (as it is the title)
+  # - read textLine+ into a variable
+  # - then count blankLines
+  # - once the next textLine appears, print textLine+ blankLine* as these
+  #   aren't footer
+  # - in END, the last textLine+ block is available for footer parsing
+  awk '
+  BEGIN {
+    # while we start with the assumption that textLine+
+    # is a footer, the first block is not.
+    isFooter = 0
+    footerComment = 0
+    blankLines = 0
+  }
+
+  # Skip lines starting with commentChar without any spaces before it.
+  /^'"$commentChar"'/ { next }
+
+  # Skip the line starting with the diff command and everything after it,
+  # up to the end of the file, assuming it is only patch data.
+  # If more than one line before the diff was empty, strip all but one.
+  /^diff --git / {
+    blankLines = 0
+    while (getline) { }
+    next
+  }
+
+  # Count blank lines outside footer comments
+  /^$/ && (footerComment == 0) {
+    blankLines++
+    next
+  }
+
+  # Catch footer comment
+  /^\[[a-zA-Z0-9-]+:/ && (isFooter == 1) {
+    footerComment = 1
+  }
+
+  /]$/ && (footerComment == 1) {
+    footerComment = 2
+  }
+
+  # We have a non-blank line after blank lines. Handle this.
+  (blankLines > 0) {
+    print lines
+    for (i = 0; i < blankLines; i++) {
+      print ""
+    }
+
+    lines = ""
+    blankLines = 0
+    isFooter = 1
+    footerComment = 0
+  }
+
+  # Detect that the current block is not the footer
+  (footerComment == 0) && (!/^\[?[a-zA-Z0-9-]+:/ || /^[a-zA-Z0-9-]+:\/\//) {
+    isFooter = 0
+  }
+
+  {
+    # We need this information about the current last comment line
+    if (footerComment == 2) {
+      footerComment = 0
+    }
+    if (lines != "") {
+      lines = lines "\n";
+    }
+    lines = lines $0
+  }
+
+  # Footer handling:
+  # If the last block is considered a footer, splice in the Change-Id at the
+  # right place.
+  # Look for the right place to inject Change-Id by considering
+  # CHANGE_ID_AFTER. Keys listed in it (case insensitive) come first,
+  # then Change-Id, then everything else (eg. Signed-off-by:).
+  #
+  # Otherwise just print the last block, a new line and the Change-Id as a
+  # block of its own.
+  END {
+    unprinted = 1
+    if (isFooter == 0) {
+      print lines "\n"
+      lines = ""
+    }
+    changeIdAfter = "^(" tolower("'"$CHANGE_ID_AFTER"'") "):"
+    numlines = split(lines, footer, "\n")
+    for (line = 1; line <= numlines; line++) {
+      if (unprinted && match(tolower(footer[line]), changeIdAfter) != 1) {
+        unprinted = 0
+        print "Change-Id: I'"$id"'"
+      }
+      print footer[line]
+    }
+    if (unprinted) {
+      print "Change-Id: I'"$id"'"
+    }
+  }' "$MSG" > "$T" && mv "$T" "$MSG" || rm -f "$T"
+}
+
+_gen_changeid_input() {
+  echo "tree `git write-tree`"
+  if parent=`git rev-parse "HEAD^0" 2>/dev/null`
+  then
+    echo "parent $parent"
+  fi
+  echo "author `git var GIT_AUTHOR_IDENT`"
+  echo "committer `git var GIT_COMMITTER_IDENT`"
+  echo
+  printf '%s' "$clean_message"
+}
+
+_gen_changeid() {
+  _gen_changeid_input |
+  git hash-object -t commit --stdin
+}
+
 #
 # It's showtime.
 #
@@ -299,6 +456,8 @@ while true; do
   read_commit_message
 
   validate_commit_message
+
+  add_change_id
 
   # if there are no WARNINGS are empty then we're good to break out of here
   test ${#WARNINGS[@]} -eq 0 && exit 0;


### PR DESCRIPTION
To prepare for code review systems like Gerrit, every git commit message must include a Change‑Id.

Gerrit groups commits into a single review using a Change-Id in the commit message footer. e.g., if a change needs updating, a follow-up commit can address issues, and Gerrit will link the new version to the original review—even across cherry-picks and rebases.

Reference:
  https://gerrit-review.googlesource.com/Documentation/user-changeid.html

Change-Id: Ib344622a3887387f9ac954dcd599c4ba45836419