### PR TITLE
Clarify the values for list poison

### DIFF
--- a/list.h
+++ b/list.h
@@ -150,8 +150,8 @@ static inline void list_del(struct list_head *node)
     prev->next = next;
 
 #ifdef LIST_POISONING
-    node->prev = (struct list_head *) (0x00100100);
-    node->next = (struct list_head *) (0x00200200);
+    node->next = NULL;
+    node->prev = NULL;
 #endif
 }
 

--- a/scripts/checksums
+++ b/scripts/checksums
@@ -1,3 +1,3 @@
 db6784ff3917888db4d1dceaa0570d99ed40e762  queue.h
-a99303fdca46c2121c61f7b96346de55226d0086  list.h
+a35ff719849dbe38d903576a332989c5ba7242bf  list.h
 3bb0192cee08d165fd597a9f6fbb404533e28fcf  scripts/check-commitlog.sh


### PR DESCRIPTION
In the Linux kernel, LIST_POISON1 (0x00100100) and LIST_POISON2 (0x00200200) mark freed list nodes so that any later access triggers a fault, catching use-after-free errors. These values are chosen because they lie in the kernel’s virtual address space, are unlikely to be valid pointers, and are easily recognizable in crash dumps.

In kernel space this works reliably because the kernel controls the address space and reserves low addresses. In userspace, however, memory is managed differently—with ASLR and possible mappings, these poison addresses might not be unmapped, so dereferencing them may not always fault. For userspace, using NULL (0x0) or custom invalid pointers—and combining poisoning with runtime checks—is a better strategy.

Change-Id: Ifd99e41497d20ce14950826ee20a36170d818e39