### PR TITLE
Avoid using generic subjects

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -10,7 +10,7 @@
  *   cppcheck-suppress nullPointer
  */
 
-
+/* Change */
 /* Create an empty queue */
 struct list_head *q_new()
 {

--- a/scripts/commit-msg.hook
+++ b/scripts/commit-msg.hook
@@ -288,11 +288,14 @@ validate_commit_message() {
   # Count non-comment, non-blank lines excluding "Change-Id:".
   NON_COMMENT_COUNT=$(sed '/^[[:space:]]*#/d;/^[[:space:]]*$/d;/^[[:space:]]*Change-Id:/d' "${COMMIT_MSG_FILE}" | wc -l | xargs)
 
-  # If the subject is oversimplified for a queue function OR queue.c is modified,
-  # and there is only one meaningful line, issue a warning.
-  if { [[ "${COMMIT_SUBJECT_TO_PROCESS}" =~ ^(Implement|Finish|Complete)[[:space:]]+q_[[:alnum:]_]+\(?\)?$ ]] || \
-     git diff --cached --name-only | grep -Eq '(^|/)queue\.c$'; } && [ "${NON_COMMENT_COUNT}" -le 1 ]; then
-    add_warning 1 "Commit message oversimplified. Use the commit message body to explain what and why."
+  # If queue.c is modified and the commit message is oversimplified, forbid generic subjects.
+  if git diff --cached --name-only | grep -Eq '(^|/)queue\.c$'; then
+    if [ "${NON_COMMENT_COUNT}" -le 1 ]; then
+      add_warning 1 "Commit message oversimplified. Use the commit message body to explain what and why."
+    fi
+    if [[ "${COMMIT_SUBJECT_TO_PROCESS}" =~ ^(Complete|Finish|Done)[[:space:]]+ ]]; then
+      add_warning 1 "Avoid using generic subjects starting with 'Complete', 'Finish', or 'Done'"
+    fi
   fi
 
   # 9. Do not start the subject line with whitespace


### PR DESCRIPTION
Generic subjects like "Complete," "Finish," or "Done" are problematic because they:
1. Lack specificity, making it unclear what was actually changed.
2. Are ambiguous and provide poor historical context.
3. Assume finality, whereas in engineering practice, designs are always subject to further refinement or improvement.

Change-Id: I8c27d25c9844d70618ce166579bee2cd3ef7c93d