### PR TITLE
Tweak Cppcheck suppression and use build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ qtest
 .devcontainer
 core*
 .cmd_history
+.out
 
 # ctags files
 TAGS

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ clean:
 	(cd traces; rm -f *~)
 
 distclean: clean
-	rm -f .cmd_history
+	-rm -f .cmd_history
+	-rm -rf .out
 
 -include $(deps)

--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -8,21 +8,32 @@ done
 # We suppress the checkLevelNormal warning for Cppcheck versions 2.11 and above.
 # Please refer to issues/153 for more details.
 CPPCHECK_suppresses="--inline-suppr harness.c \
+--suppress=unmatchedSuppression \
+--suppress=normalCheckLevelMaxBranches \
 --suppress=missingIncludeSystem \
 --suppress=noValidConfiguration \
 --suppress=unusedFunction \
 --suppress=identicalInnerCondition:log2_lshift16.h \
 --suppress=nullPointerRedundantCheck:report.c \
 --suppress=nullPointerRedundantCheck:harness.c \
+--suppress=nullPointerOutOfMemory:harness.c \
+--suppress=staticFunction:harness.c \
+--suppress=nullPointerRedundantCheck:queue.c \
+--suppress=constParameterPointer:queue.c \
 --suppress=nullPointer:queue.c \
 --suppress=nullPointer:qtest.c \
 --suppress=returnDanglingLifetime:report.c \
 --suppress=constParameterCallback:console.c \
 --suppress=constParameterPointer:console.c \
+--suppress=staticFunction:console.c \
 --suppress=checkLevelNormal:log2_lshift16.h \
 --suppress=preprocessorErrorDirective:random.h \
+--suppress=constVariablePointer:linenoise.c \
+--suppress=staticFunction:linenoise.c \
+--suppress=nullPointerOutOfMemory:web.c \
+--suppress=staticFunction:web.c \
 "
-CPPCHECK_OPTS="-I. --enable=all --error-exitcode=1 --force $CPPCHECK_suppresses $CPPCHECK_unmatched ."
+CPPCHECK_OPTS="-I. --enable=all --error-exitcode=1 --force $CPPCHECK_suppresses $CPPCHECK_unmatched --cppcheck-build-dir=.out ."
 
 RETURN=0
 CLANG_FORMAT=$(which clang-format)
@@ -32,6 +43,7 @@ if [ $? -ne 0 ]; then
 fi
 
 CPPCHECK=$(which cppcheck)
+mkdir -p .out
 if [ $? -ne 0 ]; then
     echo "[!] cppcheck not installed. Unable to perform static analysis." >&2
     exit 1
@@ -127,6 +139,7 @@ do
 done
 
 # static analysis
+echo "Running static analysis..."
 $CPPCHECK $CPPCHECK_OPTS >/dev/null
 if [ $? -ne 0 ]; then
     RETURN=1


### PR DESCRIPTION
Cppcheck is under active development and its command-line options can change. This commit updates the suppression list to work with versions 1.9 through 2.6. Additionally, while using a build directory for Cppcheck is optional, it is recommended to store analyzer output in a dedicated directory.

Change-Id: I0a3043332661e7b4dc32dadf896cb4792774cdcd