### PR TITLE
Refine trace command descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Trace files
   * They are short and simple.
   * We encourage to study them to see what tests are being performed.
   * XX is the trace number (1-17).  CAT describes the general nature of the test.
+  * All functions that need to be implemented are explicitly listed.
+  * If a colon is present in the title, all functions mentioned afterwards must be correctly implemented for the test to pass.
 * `traces/trace-eg.cmd` : A simple, documented trace file to demonstrate the operation of `qtest`
 
 ## Debugging Facilities

--- a/traces/trace-01-ops.cmd
+++ b/traces/trace-01-ops.cmd
@@ -1,4 +1,4 @@
-# Test of insert_head and remove_head
+# Test of 'q_new', 'q_insert_head', and 'q_remove_head'
 option fail 0
 option malloc 0
 new

--- a/traces/trace-02-ops.cmd
+++ b/traces/trace-02-ops.cmd
@@ -1,4 +1,4 @@
-# Test of insert_head, insert_tail, remove_head, remove_tail, and delete_mid
+# Test of 'q_new', 'q_insert_head', 'q_insert_tail', 'q_remove_head', 'q_remove_tail', and 'q_delete_mid'
 option fail 0
 option malloc 0
 new

--- a/traces/trace-03-ops.cmd
+++ b/traces/trace-03-ops.cmd
@@ -1,4 +1,4 @@
-# Test of insert_head, insert_tail, remove_head, reverse and merge
+# Test of 'q_new', 'q_insert_head', 'q_remove_head', 'q_reverse', 'q_sort', and 'q_merge'
 option fail 0
 option malloc 0
 new

--- a/traces/trace-04-ops.cmd
+++ b/traces/trace-04-ops.cmd
@@ -1,4 +1,4 @@
-# Test of insert_head, insert_tail, size, swap, and sort
+# Test of 'q_new', 'q_insert_tail', 'q_insert_head', 'q_remove_head', 'q_size', 'q_swap', and 'q_sort'
 option fail 0
 option malloc 0
 new

--- a/traces/trace-05-ops.cmd
+++ b/traces/trace-05-ops.cmd
@@ -1,4 +1,4 @@
-# Test of insert_head, insert_tail, remove_head, reverse, size, swap, and sort
+# Test of 'q_new', 'q_free', 'q_insert_head', 'q_insert_tail', 'q_remove_head', 'q_reverse', 'q_size', 'q_swap', and 'q_sort'
 option fail 0
 option malloc 0
 new

--- a/traces/trace-06-ops.cmd
+++ b/traces/trace-06-ops.cmd
@@ -1,4 +1,4 @@
-# Test of insert_head, insert_tail, delete duplicate, sort, descend and reverseK
+# Test of 'q_new', 'q_free', 'q_insert_head', 'q_insert_tail', 'q_remove_head', 'q_delete_dup', 'q_sort', 'q_descend', and 'q_reverseK'
 new
 ih RAND 4
 it gerbil 3

--- a/traces/trace-07-string.cmd
+++ b/traces/trace-07-string.cmd
@@ -1,4 +1,4 @@
-# Test of truncated strings
+# Test of truncated strings: 'q_new', 'q_free', 'q_insert_head', 'q_insert_tail', 'q_remove_head', 'q_reverse', and 'q_sort'
 option fail 0
 option malloc 0
 new

--- a/traces/trace-08-robust.cmd
+++ b/traces/trace-08-robust.cmd
@@ -1,4 +1,4 @@
-# Test operations on empty queue
+# Test operations on empty queue: 'q_new', 'q_remove_head', 'q_reverse', 'q_size', and 'q_sort'
 option fail 10
 option malloc 0
 new

--- a/traces/trace-09-robust.cmd
+++ b/traces/trace-09-robust.cmd
@@ -1,4 +1,4 @@
-# Test remove_head with NULL argument
+# Test 'q_remove_head' with NULL argument: 'q_new', 'q_insert_head', and 'q_remove_head'
 option fail 10
 option malloc 0
 new

--- a/traces/trace-10-robust.cmd
+++ b/traces/trace-10-robust.cmd
@@ -1,4 +1,4 @@
-# Test operations on NULL queue
+# Test operations on NULL queue: 'q_free', 'q_insert_head', 'q_insert_tail', 'q_remove_head', 'q_reverse', 'q_size', and 'q_sort'
 option fail 10
 option malloc 0
 free

--- a/traces/trace-11-malloc.cmd
+++ b/traces/trace-11-malloc.cmd
@@ -1,4 +1,4 @@
-# Test of malloc failure on insert_head
+# Test of malloc failure on 'q_insert_head': 'q_new', and 'q_insert_head'
 option fail 30
 option malloc 0
 new

--- a/traces/trace-12-malloc.cmd
+++ b/traces/trace-12-malloc.cmd
@@ -1,4 +1,4 @@
-# Test of malloc failure on insert_tail
+# Test of malloc failure on 'q_insert_tail': 'q_new', 'q_insert_head', and 'q_insert_tail'
 option fail 50
 option malloc 0
 new

--- a/traces/trace-13-malloc.cmd
+++ b/traces/trace-13-malloc.cmd
@@ -1,4 +1,4 @@
-# Test of malloc failure on new
+# Test of malloc failure on 'q_new': 'q_new'
 option fail 10
 option malloc 50
 new

--- a/traces/trace-14-perf.cmd
+++ b/traces/trace-14-perf.cmd
@@ -1,4 +1,4 @@
-# Test performance of insert_tail, reverse, and sort
+# Test performance of 'q_new', 'q_insert_head', 'q_insert_tail', 'q_reverse', and 'q_sort'
 option fail 0
 option malloc 0
 new

--- a/traces/trace-15-perf.cmd
+++ b/traces/trace-15-perf.cmd
@@ -1,4 +1,4 @@
-# Test performance of sort with random and descending orders
+# Test performance of 'q_sort' with random and descending orders: 'q_new', 'q_free', 'q_insert_head', 'q_sort', and 'q_reverse'
 # 10000: all correct sorting algorithms are expected pass
 # 50000: sorting algorithms with O(n^2) time complexity are expected failed
 # 100000: sorting algorithms with O(nlogn) time complexity are expected pass

--- a/traces/trace-16-perf.cmd
+++ b/traces/trace-16-perf.cmd
@@ -1,4 +1,4 @@
-# Test performance of insert_tail
+# Test performance of 'q_new', 'q_insert_head', 'q_insert_tail', and 'q_reverse'
 option fail 0
 option malloc 0
 new

--- a/traces/trace-17-complexity.cmd
+++ b/traces/trace-17-complexity.cmd
@@ -1,4 +1,4 @@
-# Test if time complexity of q_insert_tail, q_insert_head, q_remove_tail, and q_remove_head is constant
+# Test if time complexity of 'q_insert_tail', 'q_insert_head', 'q_remove_tail', and 'q_remove_head' is constant
 option simulation 1
 it
 ih


### PR DESCRIPTION
During testing, an error occurred in the process of executing 'trace-03-ops.cmd'. Upon investigation, it was found that the issue was caused by an incorrect implementation of 'q_reverse'. However, this function was not explicitly listed in the trace command descriptions, which could reduce debugging efficiency. Therefore, this PR updates the descriptions in the trace command files.

This PR does not modify any test data.