### PR TITLE
Suppress Cppcheck "unused label" warnings

### DIFF
--- a/list.h
+++ b/list.h
@@ -416,7 +416,7 @@ static inline void list_move_tail(struct list_head *node,
  * works in the same way as BUILD_BUG_ON_ZERO macro of Linux kernel.
  */
 #define list_for_each_entry(entry, head, member) \
-    for (entry = (void *) 1; sizeof(struct { int : -1; }); ++(entry))
+    for (entry = (void *) 1; sizeof(struct { int i : -1; }); ++(entry))
 #endif
 
 /**
@@ -457,8 +457,8 @@ static inline void list_move_tail(struct list_head *node,
          &entry->member != (head); entry = safe,                       \
         safe = list_entry(safe->member.next, typeof(*entry), member))
 #else
-#define list_for_each_entry_safe(entry, safe, head, member)       \
-    for (entry = safe = (void *) 1; sizeof(struct { int : -1; }); \
+#define list_for_each_entry_safe(entry, safe, head, member)  \
+    for (entry = (void *) 1; sizeof(struct { int i : -1; }); \
          ++(entry), ++(safe))
 #endif
 

--- a/scripts/checksums
+++ b/scripts/checksums
@@ -1,3 +1,3 @@
 db6784ff3917888db4d1dceaa0570d99ed40e762  queue.h
-27d7a57c6bab59beda9178f240db1aa7c0062361  list.h
+9be9666430f392924f5d27caa71a412527bf9267  list.h
 3bb0192cee08d165fd597a9f6fbb404533e28fcf  scripts/check-commitlog.sh


### PR DESCRIPTION
The commit 1d68fae introduced an anonymous bit field, which triggers a false positive in Cppcheck 2.13.0 (provided by Ubuntu 24.04):
  "Label 'int' is not used. [unusedLabel]".

Although newer versions of Cppcheck resolve this issue, version 2.13 is still preferable for minimal development environment changes. Instead of switching versions, this commit drops the anonymous bit field to prevent the Cppcheck warning.