### PR TITLE
Fix commit hook breakage

### DIFF
--- a/scripts/commit-msg.hook
+++ b/scripts/commit-msg.hook
@@ -360,15 +360,15 @@ validate_commit_message() {
   URL_REGEX='^[[:blank:]]*(https?|ftp|file)://[-A-Za-z0-9+&@#/%?=~_|!:,.;]*[-A-Za-z0-9+&@#/%=~_|]'
 
   # Ensure the commit message lines are loaded into an array.
-  readarray -t commit_msg_lines < "$COMMIT_MSG_FILE"
+  readarray -t COMMIT_MSG_LINES < "$COMMIT_MSG_FILE"
 
-  for i in "${!commit_msg_lines[@]}"; do
+  for i in "${!COMMIT_MSG_LINES[@]}"; do
     # Skip the first line (the subject) since the limit applies to the body.
     if [ "$i" -eq 0 ]; then
       continue
     fi
 
-    line="${commit_msg_lines[$i]}"
+    line="${COMMIT_MSG_LINES[$i]}"
 
     # Skip lines that are comments.
     if [[ "$line" =~ ^[[:space:]]*# ]]; then


### PR DESCRIPTION
The functionality introduced in [d39d920](https://github.com/sysprog21/lab0-c/pull/209/commits/d39d920af7f9c40aef2d2de8c9eb7247fef213a2) was broken due to changes introduced in  commit [4a8b8d5](https://github.com/sysprog21/lab0-c/pull/214/commits/4a8b8d5e36ebefc626f929d80ae900e04dd4821f), where some occurrences of `COMMIT_MSG_LINES` were replaced with `commit_msg_lines` without updating all relevant functions.

This PR fixes the issue by replacing all instances of `COMMIT_MSG_LINES` with `commit_msg_lines`.