### PR TITLE
Clarify list_add documentation

### DIFF
--- a/list.h
+++ b/list.h
@@ -90,13 +90,13 @@ static inline void INIT_LIST_HEAD(struct list_head *head)
 }
 
 /**
- * list_add - Insert a node at the beginning of a circular list
+ * list_add - Insert a node after a given node in a circular list
  * @node: Pointer to the list_head structure to add.
- * @head: Pointer to the list_head structure representing the list head.
+ * @head: Pointer to the list_head structure after which to add the new node.
  *
  * Adds the specified @node immediately after @head in a circular doubly-linked
- * list, effectively placing it at the beginning. The existing first node, if
- * any, shifts to follow @node, and the list's circular structure is maintained.
+ * list. The node that previously followed @head will now follow @node, and the
+ * list's circular structure is maintained.
  */
 static inline void list_add(struct list_head *node, struct list_head *head)
 {

--- a/scripts/checksums
+++ b/scripts/checksums
@@ -1,3 +1,3 @@
 398b59c23f699ff1bf1e73a94503a9a91caa9207  queue.h
-9be9666430f392924f5d27caa71a412527bf9267  list.h
+5179cf8f5aafbc6cb8e8d7b898ef3798cfe85613  list.h
 1029c2784b4cae3909190c64f53a06cba12ea38e  scripts/check-commitlog.sh


### PR DESCRIPTION
Originally, the function list_add is said to insert a node at the beginning of a given list.
However, it could also be used to insert a node after any existing node in the list. 

Therefore, this pr modifies its documentation to reflect the actual list manipulation performed by the function.