### PR TITLE
Remove similar trailer keys from commit hook

### DIFF
--- a/scripts/commit-msg.hook
+++ b/scripts/commit-msg.hook
@@ -140,8 +140,7 @@ build_commit_trailer_regex() {
 
   # Predefined trailer keys.
   trailers=(
-    'CC' 'Change-Id'
-    'Bug' 'Close' 'Closes'
+    'CC' 'Change-Id' 'Closes'
     'Acked-by' 'Co-authored-by' 'Reported-by' 'Reviewed-by'
     'Signed-off-by' 'Suggested-by' 'Tested-by'
   )


### PR DESCRIPTION
The duplicated "Close" and "Closes" keys will possibly cause inconsistency between commit messages.  The one being kept is "Closes" because the implied subject is "this patch", so it should complete the following sentence:

    This patch [closes]...

just like sentences in the body of a message.

"Bug" is also removed due to its similarity to "Closes a bug".

Change-Id: Idea7c0310249c603e550a7a4e27df490efe13d4c