### PR TITLE
Fix dummy 'list_for_each_entry_safe'

### DIFF
--- a/list.h
+++ b/list.h
@@ -457,8 +457,8 @@ static inline void list_move_tail(struct list_head *node,
          &entry->member != (head); entry = safe,                       \
         safe = list_entry(safe->member.next, typeof(*entry), member))
 #else
-#define list_for_each_entry_safe(entry, safe, head, member)  \
-    for (entry = (void *) 1; sizeof(struct { int i : -1; }); \
+#define list_for_each_entry_safe(entry, safe, head, member)         \
+    for (entry = safe = (void *) 1; sizeof(struct { int i : -1; }); \
          ++(entry), ++(safe))
 #endif
 

--- a/scripts/checksums
+++ b/scripts/checksums
@@ -1,3 +1,3 @@
 398b59c23f699ff1bf1e73a94503a9a91caa9207  queue.h
-5179cf8f5aafbc6cb8e8d7b898ef3798cfe85613  list.h
+b26e079496803ebe318174bda5850d2cce1fd0c1  list.h
 1029c2784b4cae3909190c64f53a06cba12ea38e  scripts/check-commitlog.sh


### PR DESCRIPTION
The commit e0c6b113c9c9404208dcf4dccf4d229016aa4778 unintentionally deleted the assignment to 'safe' in dummy 'list_for_each_entry_safe', so the originally suppressed reports of uninitialized variables were no longer suppressed.

Closes: #229

Change-Id: Ibfe2a44e425c810b8e0b12bc44b42e6398b3b23c