### PR TITLE
Add missing parameter hints

### DIFF
--- a/console.c
+++ b/console.c
@@ -427,7 +427,7 @@ void init_cmd()
                 "Display or set options. See 'Options' section for details",
                 "[name val]");
     ADD_COMMAND(quit, "Exit program", "");
-    ADD_COMMAND(source, "Read commands from source file", "");
+    ADD_COMMAND(source, "Read commands from source file", "file");
     ADD_COMMAND(log, "Copy output to file", "file");
     ADD_COMMAND(time, "Time command execution", "cmd arg ...");
     ADD_COMMAND(web, "Read commands from builtin web server", "[port]");


### PR DESCRIPTION
The `select` command requires one parameter, but the parameter hint was missing. Referencing the `log` command, improve the parameter hint for `select`.