### PR TITLE
Avoid unnecessary spaces created by clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -24,3 +24,4 @@ ForEachMacros:
   - hlist_for_each_entry
   - rb_list_foreach
   - rb_list_foreach_safe
+SpaceBeforeParens: ControlStatementsExceptForEachMacros


### PR DESCRIPTION
Current `.clang_format` creates a space between a macro's name and the parenthesis, which does not follow the kernel coding style. The change is made so the unnecessary parenthesis will not be created.

Change-Id: I97bf12cd270c6aef03eca359e29636bb5fb3d616