### PR TITLE
Fix parsing arguments

### DIFF
--- a/console.c
+++ b/console.c
@@ -144,6 +144,8 @@ static char **parse_args(char *line, int *argcp)
             *dst++ = c;
         }
     }
+    /* Let the last substring is null-terminated */
+    *dst++ = '\0';
 
     /* Now assemble into array of strings */
     char **argv = calloc_or_fail(argc, sizeof(char *), "parse_args");


### PR DESCRIPTION
When executing the 'ih' or 'it' command with multiple leading spaces, the parsed arguments contained unexpected characters.

The problem stemmed from 'parse_args' allocating memory for 'buf' using 'malloc_or_fail', which does not initialize memory. Since 'strlen' determines string length based on the first null terminator it encounters, uninitialized memory beyond the expected input could be incorrectly read, leading to unintended characters in 'argv'.

To fix this, an explicit null terminator was added at the end of the parsing loop, ensuring proper null termination and preventing 'strlen' from reading beyond valid input.

This change guarantees correct argument parsing
even when the input contains multiple leading spaces.

Close #233

Change-Id: I178fa357962b28fd22646ab9c21542e1c780bd55