### PR TITLE
Implement q_new() to allocate and initialize list_head

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -7,7 +7,12 @@
 /* Create an empty queue */
 struct list_head *q_new()
 {
-    return NULL;
+    struct list_head *head = malloc(sizeof(struct list_head));
+    if (!head) {
+        return NULL;
+    }
+    INIT_LIST_HEAD(head);
+    return head;
 }
 
 /* Free all storage used by queue */


### PR DESCRIPTION
Added q_new() function to allocate memory for a new list_head node and initialize it using INIT_LIST_HEAD(). This ensures that the allocated list is properly initialized before use.

Change-Id: I3b2c11ea3ecb5fcbf8f32109009d2d113b6e0dde