### PR TITLE
Fix incorrect `do_size` argument usage

### DIFF
--- a/qtest.c
+++ b/qtest.c
@@ -544,7 +544,7 @@ static bool do_size(int argc, char *argv[])
     bool ok = true;
     if (argc == 2) {
         if (!get_int(argv[1], &reps))
-            report(1, "Invalid number of calls to size '%s'", argv[2]);
+            report(1, "Invalid number of calls to size '%s'", argv[1]);
     }
 
     int cnt = 0;


### PR DESCRIPTION
This change corrects a bug in the `do_size` function and reformats `qtest.c` to comply with the updated clang-format configuration introduced in commit c9f7b87. The formatting update is required because clang-format will reject commits that do not conform to the enforced style.  

In `do_size`, the error message incorrectly referenced `argv[2]`, which is always `NULL` when `argc` is 2:

> "The value of argv[argc] shall be a null pointer."  
> *(ISO/IEC 9899:2011, Section 5.1.2.2.1)*  

Additionally, according to the C11 standard, passing a `NULL` pointer to '%s' results in undefined behavior:

> "If an argument to a function has an invalid value (such as a value outside the domain of the function, or a pointer outside the address space of the program, or a null pointer, or a pointer to non-modifiable storage when the corresponding parameter is not const-qualified) or a type (after promotion) not expected by a function with variable number of arguments, the behavior is undefined."  
> *(ISO/IEC 9899:2011, Section 7.1.4 - 1)*  

This update changes the argument to `argv[1]`, ensuring the accuracy of the error message's meaning and that a valid pointer is always used.