### PR TITLE
Introduce EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab
+indent_size = 4
+max_line_length = 80
+
+[**/*.[ch]]
+indent_style = space
+indent_size = 4
+max_line_length = 80
+
+[{**/*.py,.ci/*}]
+indent_style = space
+indent_size = 4
+
+[{scripts/*,.github/workflows/*}]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,25 +10,25 @@ jobs:
     - uses: webfactory/ssh-agent@v0.7.0
       continue-on-error: true
       with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+        ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
     - name: install-dependencies
       run: |
-            .ci/check-sanity.sh
-            sudo apt-get update
-            sudo apt-get -q -y install build-essential cppcheck
+        .ci/check-sanity.sh
+        sudo apt-get update
+        sudo apt-get -q -y install build-essential cppcheck
     - name: make
       run:  |
-            git clone git@github.com:sysprog21/lab0-c-private || echo "No provisioning profile found"
-            .ci/check-provisioning.sh
-            make
+        git clone git@github.com:sysprog21/lab0-c-private || echo "No provisioning profile found"
+        .ci/check-provisioning.sh
+        make
     - name: make check
       run: |
-            make check || (cat scripts/weeping.raw ; exit 1)
-            cat scripts/kirby.raw
+        make check || (cat scripts/weeping.raw ; exit 1)
+        cat scripts/kirby.raw
     - name: make test
       run: |
-            make test || (cat scripts/weeping.raw ; exit 1)
-            cat scripts/kirby.raw
+        make test || (cat scripts/weeping.raw ; exit 1)
+        cat scripts/kirby.raw
 
   coding-style:
     runs-on: ubuntu-24.04
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: coding convention
       run: |
-            sudo apt-get install -q -y clang-format-18
-            .ci/check-newline.sh
-            .ci/check-format.sh
+        sudo apt-get install -q -y clang-format-18
+        .ci/check-newline.sh
+        .ci/check-format.sh
       shell: bash

--- a/scripts/aspell-pws
+++ b/scripts/aspell-pws
@@ -350,3 +350,4 @@ typedef
 BitInt
 noreturn
 pragma
+EditorConfig

--- a/scripts/commit-msg.hook
+++ b/scripts/commit-msg.hook
@@ -119,7 +119,7 @@ get_all_match_positions() {
 
     # skip if the target is not found
     [ -z "$result" ] && continue
-    
+
     # output and update states
     local line col
     read -r line col <<< "$result"
@@ -250,13 +250,13 @@ validate_commit_message() {
   # ------------------------------------------------------------------------------
   ASPELL=$(which aspell)
   if [ $? -ne 0 ]; then
-      echo "Aspell not installed - unable to check spelling"
+    echo "Aspell not installed - unable to check spelling"
   else
-      LINE_NUMBER=1
-      MISSPELLED_WORDS=$(echo "$COMMIT_MSG_LINES[LINE_NUMBER]" | $ASPELL --lang=en --list --home-dir=scripts --personal=aspell-pws)
-      if [ -n "$MISSPELLED_WORDS" ]; then
-        add_warning LINE_NUMBER "Possible misspelled word(s): $MISSPELLED_WORDS"
-      fi
+    LINE_NUMBER=1
+    MISSPELLED_WORDS=$(echo "$COMMIT_MSG_LINES[LINE_NUMBER]" | $ASPELL --lang=en --list --home-dir=scripts --personal=aspell-pws)
+    if [ -n "$MISSPELLED_WORDS" ]; then
+      add_warning LINE_NUMBER "Possible misspelled word(s): $MISSPELLED_WORDS"
+    fi
   fi
 
   # 1. Separate subject from body with a blank line
@@ -453,7 +453,7 @@ validate_commit_message() {
   FULL_COMMIT_MSG_WITH_SPACE=$(sed '/^[[:space:]]*#/d' "$COMMIT_MSG_FILE" | \
                                sed -E "/$TRAILER_REGEX/d" | sed -E "s@${URL_REGEX#^}@@g")
   FULL_COMMIT_MSG=$(echo "$FULL_COMMIT_MSG_WITH_SPACE" | sed '/^[[:space:]]*$/d')
-  
+
   # Extended list of abusive words (case-insensitive).
   # Adjust the list as needed.
   ABUSIVE_WORDS_REGEX='\b(fuck|fucking|dick|shit|bitch|asshole|cunt|motherfucker|damn|crap|dumbass|piss)\b'
@@ -475,7 +475,7 @@ validate_commit_message() {
     -e "s/(['\"][^'\"]*['\"])//g" \
     -e "s/\bcommit[[:space:]]+[0-9a-fA-F]{7,40}\b/commit/g")
   MSG_FOR_SPELLCHECK=$(echo "$MSG_FOR_SPELLCHECK_LINE_FINDING" | sed '/^[[:space:]]*$/d')
-  
+
   # Use aspell to list misspelled words according to American English, ignoring quoted text.
   MISSPELLED_WORDS=$(echo "$MSG_FOR_SPELLCHECK" | $ASPELL --lang=en --list --home-dir=scripts --personal=aspell-pws)
   if [ -n "$MISSPELLED_WORDS" ]; then
@@ -656,8 +656,7 @@ _gen_changeid_input() {
 }
 
 _gen_changeid() {
-  _gen_changeid_input |
-  git hash-object -t commit --stdin
+  _gen_changeid_input | git hash-object -t commit --stdin
 }
 
 # It's showtime.

--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -248,7 +248,7 @@ fi
 # Cross platform projects tend to avoid non-ASCII filenames; prevent
 # them from being added to the repository.
 if test $(git diff --cached --name-only --diff-filter=A -z $against |
-        LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+          LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
 then
   cat <<\EOF
 ERROR: Attempt to add a non-ASCII file name.

--- a/scripts/prepare-commit-msg.hook
+++ b/scripts/prepare-commit-msg.hook
@@ -4,7 +4,7 @@ COMMIT_MSG_FILE="$1"
 
 # If the commit message file already contains non-comment lines, do nothing.
 if grep -qE '^[^[:space:]#]' "$COMMIT_MSG_FILE"; then
-    exit 0
+  exit 0
 fi
 
 # Gather a list of staged (changed) files.


### PR DESCRIPTION
Originally, the indentation of the scripts was not unified: ones in 'scripts/' used 2 spaces, and ones in '.ci/' used 4. Even though the former used 2 spaces, the style was not implemented well as some indents in the files were 4 spaces.

This patch unifies the style of the scripts, and note it with an EditorConfig file. EditorConfig is used because it's supported out-of-the-box by many editors, helping the auto-indent functionality works.

Change-Id: I41be8779ef5b0e94192c144bb48605625727963f