### PR TITLE
Ensure repetitions input is at least 1

### DIFF
--- a/qtest.c
+++ b/qtest.c
@@ -210,7 +210,7 @@ static bool queue_insert(position_t pos, int argc, char *argv[])
 
     char *inserts = argv[1];
     if (argc == 3) {
-        if (!get_int(argv[2], &reps)) {
+        if (!get_int(argv[2], &reps) || reps < 1) {
             report(1, "Invalid number of insertions '%s'", argv[2]);
             return false;
         }


### PR DESCRIPTION
Passing 0 or a negative value for repetitions does not cause errors, as the input is an integer. However, this behavior may be confusing for users. To improve clarity, enforce repetitions to be an integer greater than or equal to 1 and return an error if the input is invalid.

Change-Id: Ifbe1e1846f6eac2c933a00a3a9af5d4c533f3c5f