### PR TITLE
Fix BSD compatibility

### DIFF
--- a/scripts/check-repo.sh
+++ b/scripts/check-repo.sh
@@ -65,7 +65,7 @@ REPO_NAME="lab0-c"
 repo_html=$(curl -s "https://github.com/${REPO_OWNER}/${REPO_NAME}")
 
 # Extract the default branch name from data-default-branch="..."
-DEFAULT_BRANCH=$(echo "$repo_html" | grep -oP "/${REPO_OWNER}/${REPO_NAME}/blob/\K[^/]+(?=/LICENSE)" | head -n 1)
+DEFAULT_BRANCH=$(echo "$repo_html" | sed -nE "s#.*${REPO_OWNER}/${REPO_NAME}/blob/([^/]+)/LICENSE.*#\1#p" | head -n 1)
 
 if [ "$DEFAULT_BRANCH" != "master" ]; then
   echo "$DEFAULT_BRANCH"
@@ -80,8 +80,7 @@ curl -sSL -o "$temp_file" "$COMMITS_URL"
 
 # general grep pattern that finds commit links
 upstream_hash=$(
-  grep -Po 'href="[^"]*/commit/\K[0-9a-f]{40}' "$temp_file" \
-  | head -n 1
+  sed -nE 's/.*href="[^"]*\/commit\/([0-9a-f]{40}).*/\1/p' "$temp_file" | head -n 1
 )
 
 rm -f "$temp_file"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -89,14 +89,14 @@ make_random_string() {
 
   if [ -z "$sub_str" ]; then
     # Produce an exact random string of length total_len
-    cat /dev/urandom | tr -dc 'a-z0-9' | head -c "$total_len"
+    cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c "$total_len"
   else
     # Insert the substring at a random position
     local sub_len=${#sub_str}
     local rand_len=$(( total_len - sub_len ))
 
     local raw_rand
-    raw_rand=$(cat /dev/urandom | tr -dc 'a-z0-9' | head -c "$rand_len")
+    raw_rand=$(cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c "$rand_len")
 
     local pos=$(( RANDOM % (rand_len + 1) ))
     echo "${raw_rand:0:pos}${sub_str}${raw_rand:pos}"


### PR DESCRIPTION
On macOS, Perl-compatible regex option (-P) in GNU grep is not available by default. It can be replaced with sed. While using 'tr', it is necessary to set the locale to "C" ensures that tr interprets the byte stream in a consistent, ASCII-only manner. This prevents errors like "Illegal byte sequence" on BSD systems such as macOS.

Change-Id: I1c134092a5fb2afc8018a638e172fb0b380e0fdd