### PR TITLE
Update Linux version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There are a few prerequisites which must be installed on your machine before you
 be able to build and run the autograders.
 
 The following command will install all required and optional dependencies on Ubuntu
-Linux 20.04 or later:
+Linux 24.04 or later:
 ```shell
 $ sudo apt install build-essential git clang-format cppcheck aspell colordiff valgrind
 ```


### PR DESCRIPTION
Change required Linux version from Ubuntu 20.04 or later to Ubuntu 24.04 or later in README, aligning with the [2025 Linux Kernel Implementation lab0 website specifications](https://hackmd.io/@sysprog/linux2025-lab0/%2F%40sysprog%2Flinux2025-lab0-a#-%E9%96%8B%E7%99%BC%E7%92%B0%E5%A2%83%E8%A8%AD%E5%AE%9A).