### PR TITLE
Correct order of Co-authored-by in commit footer

### DIFF
--- a/scripts/commit-msg.hook
+++ b/scripts/commit-msg.hook
@@ -613,12 +613,29 @@ add_change_id() {
     }
     changeIdAfter = "^(" tolower("'"$CHANGE_ID_AFTER"'") "):"
     numlines = split(lines, footer, "\n")
+
+    # Find the last line that starts with a comment character.
+    coauthorIndex = 0
+    for (line = 1; line <= numlines; line++) {
+      if (match(tolower(footer[line]), /^co-authored-by:/)) {
+        coauthorIndex = line
+      }
+    }
+
     for (line = 1; line <= numlines; line++) {
       if (unprinted && match(tolower(footer[line]), changeIdAfter) != 1) {
-        unprinted = 0
-        print "Change-Id: I'"$id"'"
+        # If the Change-Id is the first line in the footer, print it first.
+        if (coauthorIndex == 0 || line > coauthorIndex) {
+          print "Change-Id: I'"$id"'"
+          unprinted = 0
+        }
       }
       print footer[line]
+
+      if(line == coauthorIndex && unprinted) {
+        print "Change-Id: I'"$id"'"
+        unprinted = 0
+      }
     }
     if (unprinted) {
       print "Change-Id: I'"$id"'"


### PR DESCRIPTION
This fix ensures that `Co-authored-by` is properly placed above `change-Id` in the commit footer.


Change-Id: I856457b5575a967096ad71c9e4271b45b8d1400a