### PR TITLE
Improve log command feedback

### DIFF
--- a/console.c
+++ b/console.c
@@ -370,7 +370,7 @@ static bool do_source(int argc, char *argv[])
 static bool do_log(int argc, char *argv[])
 {
     if (argc < 2) {
-        report(1, "No log file given");
+        report(1, "No log file given. Use 'log <file>'.");
         return false;
     }
 
@@ -378,6 +378,7 @@ static bool do_log(int argc, char *argv[])
     if (!result)
         report(1, "Couldn't open log file '%s'", argv[1]);
 
+    printf("Logging enabled: %s\n", argv[1]);
     return result;
 }
 


### PR DESCRIPTION
Enhance the `log` command by providing clearer feedback to users. Now, if no log file is specified, the message explicitly suggests using `log <file>` for better clarity. Additionally, a message is printed when logging is enabled, improving user awareness.

Before: Ambiguous log command feedback
```shell
$ ./qtest
cmd> log
No log file given
cmd> log temp.txt
cmd> new
l = []
cmd> quit
Freeing queue
$
```
After: Clear and informative log command messages
```shell
$ ./qtest
cmd> log
No log file given. Use 'log <file>'. 
cmd> log temp.txt
Logging enabled: temp.txt 
cmd> new
l = []
cmd> quit
Freeing queue
$
$ cat temp.txt
l = []
Freeing queue
$
```

Change-Id: I355f3f13bd959ddecc2893d202642accc565fb8a