### PR TITLE
Improve source command feedback

### DIFF
--- a/console.c
+++ b/console.c
@@ -355,7 +355,7 @@ static bool do_option(int argc, char *argv[])
 static bool do_source(int argc, char *argv[])
 {
     if (argc < 2) {
-        report(1, "No source file given");
+        report(1, "No source file given. Use 'source <file>'.");
         return false;
     }
 


### PR DESCRIPTION
Enhance the `source` command by providing clearer feedback to users. Now, if no source file is specified, the message explicitly suggests using `source <file>` for better clarity. Additionally, a message is printed when sourcing a file, improving user awareness.

Before: Ambiguous source command feedback
```shell
$ cat src.txt
new
free
quit
$./qtest
cmd> source
No source file given
cmd> source src.txt
cmd> new
l = []
cmd> free
l = NULL
cmd> quit
Freeing queue
$
```
After: Clear and informative source command messages
```shell
$ ./qtest
cmd> source
No source file given. Use 'source <file>'.
cmd> source src.txt
Sourcing from: src.txt
cmd> new
l = []
cmd> free
l = NULL
cmd> quit
Freeing queue
$ 
```

Change-Id: Ia1f5b9118ee369850ac6cc68f4e8344114c34a15