### PR TITLE
Fix misleading comment

### DIFF
--- a/console.c
+++ b/console.c
@@ -588,7 +588,7 @@ static int cmd_select(int nfds,
         FD_ZERO(readfds);
         FD_SET(infd, readfds);
 
-        /* If web not ready listen */
+        /* If web_fd is available, add to readfds */
         if (web_fd != -1)
             FD_SET(web_fd, readfds);
 


### PR DESCRIPTION
The previous comments incorrectly suggested that the file descriptor was not yet ready. In fact, the check (web_fd != -1) ensures that web_fd is valid and should be monitored in the read set. This commit updates the comment to clearly state that web_fd is available, providing an accurate description of the code's behavior.

Change-Id: Ib81d417a848e1cf41f289bd2abafb2de1c8a23d8