### PR TITLE
Skip fmtscan on macOS

### DIFF
--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -235,17 +235,20 @@ for file in $C_FILES; do
 done
 
 # format string checks
-if [ ! -f fmtscan ]; then
+if [[ "$OSTYPE" != darwin* ]]; then
+  # Format string checks
+  if [ ! -f fmtscan ]; then
     make fmtscan
     if [ ! -f fmtscan ]; then
-       throw "Fail to build 'fmtscan' tools"
+      throw "Fail to build 'fmtscan' tool"
     fi
-fi
-if [ -n "$C_FILES" ]; then
-  echo "Running fmtscan..."
-  ./fmtscan
-  if [ $? -ne 0 ]; then
-    throw "Check format strings for spelling"
+  fi
+  if [ -n "$C_FILES" ]; then
+    echo "Running fmtscan..."
+    ./fmtscan
+    if [ $? -ne 0 ]; then
+      throw "Check format strings for spelling"
+    fi
   fi
 fi
 


### PR DESCRIPTION
The tool 'fmtscan' requires POSIX message queues which are unavailable on macOS. Skip build and execution of 'fmtscan' on non-Linux platforms.

Change-Id: I5648a61b94a87b1a691c14e12fb3d75c11d3dfa1