### PR TITLE
Check syntax for changed shell scripts

### DIFF
--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -207,6 +207,21 @@ for FILE in $C_FILES; do
   fi
 done
 
+# Check syntax for changed shell scripts
+SHELL_FILES=()
+for file in "${FILES[@]}"; do
+  if [[ "$file" =~ ^scripts/common\.sh$ || "$file" =~ ^scripts/.*\.hook$ ]]; then
+    SHELL_FILES+=("$file")
+  fi
+done
+if [ "${#SHELL_FILES[@]}" -gt 0 ]; then
+  for file in "${SHELL_FILES[@]}"; do
+    if ! bash -n "$file"; then
+      throw "Syntax errors detected in $file." >&2
+    fi
+  done
+fi
+
 # Show insertion and deletion counts.
 if [ "${#FILES[@]}" -gt 0 ]; then
   echo "Following files were changed:"


### PR DESCRIPTION
If any relevant script is found, the hook runs 'bash -n' to verify its syntax.

Change-Id: If1f29966228d36bdb4022a822a14e87956bbb825