### PR TITLE
Ensure K value in reverseK is at least 1

### DIFF
--- a/qtest.c
+++ b/qtest.c
@@ -823,8 +823,8 @@ static bool do_reverseK(int argc, char *argv[])
     error_check();
 
     if (argc == 2) {
-        if (!get_int(argv[1], &k)) {
-            report(1, "Invalid number of K");
+        if (!get_int(argv[1], &k) || k < 1) {
+            report(1, "Invalid number of K (at least 1)");
             return false;
         }
     } else {


### PR DESCRIPTION
Passing 0 or a negative value for K does not cause errors, as the input is an integer. However, this behavior may be confusing for users. To improve clarity, enforce K to be an integer greater than or equal to 1 and return an error if the input is invalid.

Change-Id: Ic68c1acbbd45153da8c3d7682d9251eec9ce597f

Before
```shell
$ ./qtest
cmd> new
l = []
cmd> it a
l = [a]
cmd> it b
l = [a b]
cmd> reverseK 2
l = [b a]
cmd> reverseK 0
l = [b a]
cmd> reverseK -1
l = [b a]
cmd> free
l = NULL
cmd> quit
Freeing queue
$
```
After
```shell
$ ./qtest
cmd> new
l = []
cmd> it a
l = [a]
cmd> it b
l = [a b]
cmd> reverseK 2
l = [b a]
cmd> reverseK 0
Invalid number of K = '0'
cmd> reverseK -1
Invalid number of K = '-1'
cmd> free
l = NULL
cmd> quit
Freeing queue
$ 
```