### PR TITLE
Fix missing Change-Id

### DIFF
--- a/scripts/commit-msg.hook
+++ b/scripts/commit-msg.hook
@@ -186,7 +186,7 @@ build_commit_trailer_regex() {
   done < <(git config --get-regexp 'trailer.*.key')
 
   if [[ ${#trailers_by[@]} -eq 0 ]]; then
-    trailers_by=("${DEFAULT_TRAILERS_BY[@]}")
+    trailers_by=("${KNOWN_TRAILERS_BY[@]}")
   fi
 
   # Possible trailers :


### PR DESCRIPTION
The previous pull request 43a311d  mistakenly set the `trailers_by` variable to `DEFAULT_TRAILERS_BY`, causing the change ID to disappear. Change the variable to `KNOWN_TRAILERS_BY` to ensure the change ID appears correctly.
Close #267
Change-Id: I4e3b4bfa06aba31bed2c26925ecfa5593a3d327b