### PR TITLE
Unset locale when validating directory names

### DIFF
--- a/scripts/commit-msg.hook
+++ b/scripts/commit-msg.hook
@@ -476,7 +476,7 @@ validate_commit_message() {
 
   # Alert if the commit message appears to be written in Chinese.
   # This pattern matches any Chinese character (common CJK Unified Ideographs).
-  MISSPELLED_WORDS=$(echo "$FULL_COMMIT_MSG" | grep "[一-龥]")
+  MISSPELLED_WORDS=$(echo "$FULL_COMMIT_MSG" | LC_ALL=C grep "[一-龥]")
   if [ -n "$MISSPELLED_WORDS" ]; then
     add_warning 1 "Commit message appears to be written in Chinese: $MISSPELLED_WORDS"
   fi

--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -99,7 +99,7 @@ RETURN=0
 
 # Disallow non-ASCII characters in workspace path
 workspace=$(git rev-parse --show-toplevel)
-if echo "$workspace" | grep -q "[一-龥]"; then
+if echo "$workspace" | LC_ALL=C grep -q "[一-龥]"; then
   throw "The workspace path '$workspace' contains non-ASCII characters."
 fi
 


### PR DESCRIPTION
This commit resolves the "Invalid collation character" error thrown by 'grep' when validating directory names with special characters. It sets locale to "C" before running 'grep'.

Change-Id: Ia005744cfc1799dff0148602bcb99d947f8c805d