### PR TITLE
Correct grammar in queue.h function descriptions

### DIFF
--- a/queue.h
+++ b/queue.h
@@ -182,7 +182,7 @@ void q_reverse(struct list_head *head);
  * @k: is a positive integer and is less than or equal to the length of the
  * linked list.
  *
- * No effect if queue is NULL or empty. If there has only one element, do
+ * No effect if queue is NULL or empty. If there is only one element, do
  * nothing.
  *
  * Reference:
@@ -195,7 +195,7 @@ void q_reverseK(struct list_head *head, int k);
  * @head: header of queue
  * @descend: whether or not to sort in descending order
  *
- * No effect if queue is NULL or empty. If there has only one element, do
+ * No effect if queue is NULL or empty. If there is only one element, do
  * nothing.
  */
 void q_sort(struct list_head *head, bool descend);
@@ -205,7 +205,7 @@ void q_sort(struct list_head *head, bool descend);
  * value anywhere to the right side of it.
  * @head: header of queue
  *
- * No effect if queue is NULL or empty. If there has only one element, do
+ * No effect if queue is NULL or empty. If there is only one element, do
  * nothing.
  *
  * Reference:
@@ -220,7 +220,7 @@ int q_ascend(struct list_head *head);
  * value anywhere to the right side of it.
  * @head: header of queue
  *
- * No effect if queue is NULL or empty. If there has only one element, do
+ * No effect if queue is NULL or empty. If there is only one element, do
  * nothing.
  *
  * Reference:

--- a/scripts/checksums
+++ b/scripts/checksums
@@ -1,3 +1,3 @@
-bff0704601c8197ae6b847647b4167664b7d6abc  queue.h
+25e7d2797e09bfafa0c0dee70111104648faec9d  queue.h
 b26e079496803ebe318174bda5850d2cce1fd0c1  list.h
 1029c2784b4cae3909190c64f53a06cba12ea38e  scripts/check-commitlog.sh


### PR DESCRIPTION
This fix addresses a grammatical error in the queue.h documentation. 
When describing existence, the correct English grammar is to use "there is" rather than "there has". Therefore, I've changed "If there has only one element" to "If there is only one element" in the comments for the q_sort(), q_ascend(), q_descend(), and q_reverseK() functions.
