### PR TITLE
Fix string operation truncation

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -948,7 +948,7 @@ static int line_edit(int stdin_fd,
         char seq[5];
 
         if (eventmux_callback != NULL) {
-            int result = eventmux_callback(l.buf);
+            int result = eventmux_callback(l.buf, l.buflen);
             if (result != 0)
                 return result;
         }

--- a/linenoise.h
+++ b/linenoise.h
@@ -54,7 +54,7 @@ typedef struct {
 typedef void(line_completion_callback_t)(const char *, line_completions_t *);
 typedef char *(line_hints_callback_t)(const char *, int *color, int *bold);
 typedef void(line_free_hints_callback_t)(void *);
-typedef int(line_eventmux_callback_t)(char *);
+typedef int(line_eventmux_callback_t)(char *, size_t);
 void line_set_completion_callback(line_completion_callback_t *);
 void line_set_hints_callback(line_hints_callback_t *);
 void line_set_free_hints_callback(line_free_hints_callback_t *);

--- a/qtest.c
+++ b/qtest.c
@@ -1401,7 +1401,7 @@ int main(int argc, char *argv[])
         }
         case 'l':
             strncpy(lbuf, optarg, BUFSIZE);
-            buf[BUFSIZE - 1] = '\0';
+            lbuf[BUFSIZE - 1] = '\0';
             logfile_name = lbuf;
             break;
         default:

--- a/scripts/aspell-pws
+++ b/scripts/aspell-pws
@@ -77,6 +77,7 @@ epoll
 errno
 etc
 eventfd
+eventmux
 fadvise
 fchdir
 fchmod

--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -44,6 +44,7 @@ cppcheck_suppressions() {
     "preprocessorErrorDirective:random.h"
     "constVariablePointer:linenoise.c"
     "staticFunction:linenoise.c"
+    "unusedStructMember:linenoise.h"
     "nullPointerOutOfMemory:web.c"
     "staticFunction:web.c"
     "constParameterCallback:tools/fmtscan.c"

--- a/web.c
+++ b/web.c
@@ -260,6 +260,7 @@ int web_eventmux(char *buf, size_t buflen)
         char *buffer = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n";
         web_send(web_connfd, buffer);
         strncpy(buf, p, buflen);
+        buf[buflen] = '\0';
         free(p);
         close(web_connfd);
         return strlen(buf);

--- a/web.c
+++ b/web.c
@@ -234,7 +234,7 @@ char *web_recv(int fd, struct sockaddr_in *clientaddr)
     return ret;
 }
 
-int web_eventmux(char *buf)
+int web_eventmux(char *buf, size_t buflen)
 {
     fd_set listenset;
 
@@ -259,7 +259,7 @@ int web_eventmux(char *buf)
         char *p = web_recv(web_connfd, &clientaddr);
         char *buffer = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n";
         web_send(web_connfd, buffer);
-        strncpy(buf, p, strlen(p) + 1);
+        strncpy(buf, p, buflen);
         free(p);
         close(web_connfd);
         return strlen(buf);

--- a/web.h
+++ b/web.h
@@ -9,6 +9,6 @@ char *web_recv(int fd, struct sockaddr_in *clientaddr);
 
 void web_send(int out_fd, char *buffer);
 
-int web_eventmux(char *buf);
+int web_eventmux(char *buf, size_t buflen);
 
 #endif


### PR DESCRIPTION
This patch fixes potential truncation caused by `strncpy`. If the destination buffer was not large enough, the string would be not null-terminated, and possibly lead to buffer overflow because of the passed buffer length depending on the source buffer.