### PR TITLE
Enhance `fmtscan` dictionary with HTML and CSS terms

### DIFF
--- a/scripts/aspell-pws
+++ b/scripts/aspell-pws
@@ -143,6 +143,7 @@ github
 glibc
 gprof
 hotfix
+href
 http
 https
 hv
@@ -201,6 +202,7 @@ mknod
 mlock
 mlockall
 mmap
+monospace
 mprotect
 mq
 mrs
@@ -287,6 +289,7 @@ regcomp
 regerror
 regexec
 regfree
+rel
 renderer
 retpoline
 reverseK


### PR DESCRIPTION
This PR updates the spelling dictionary with three terms - 'href' and 'rel' from HTML, and 'monospace' from CSS - that fmtscan marked as false positives during web integration. It fixes a flagging issue also seen in #265, ensuring reliable static analysis, but leaves #265's request for better error details in fmtscan unaddressed.

Related Issue: #265