### PR TITLE
Refine EditorConfig glob spec

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,15 +10,15 @@ indent_style = tab
 indent_size = 4
 max_line_length = 80
 
-[**/*.[ch]]
+[*.[ch]]
 indent_style = space
 indent_size = 4
 max_line_length = 80
 
-[{**/*.py,.ci/*}]
+[{*.py,/.ci/*}]
 indent_style = space
 indent_size = 4
 
-[{scripts/*,.github/workflows/*}]
+[{/scripts/*,/.github/workflows/*}]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
The glob spec of EditorConfig works in a non-intuitive way that is different from glob of POSIX-compatible shells. The pattern matching is done in the directory the target file is in instead of the EditorConfig file in, like the '.gitignore' file. Therefore, simply 'foo' matches 'foo' in the root directory and each sub-directory, and '/foo' has to be used to match the file in the root directory only.

See: https://github.com/editorconfig/editorconfig/issues/283#issuecomment-1921879402
Change-Id: Iea6d25f2ba551db0420ed1fa968f0b355046cabf