### PR TITLE
Prohibit conventional commit format in subjects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -913,6 +913,9 @@ In addition, this project expects contributors to follow these additional rules:
 * Avoid using parentheses in commit subjects.
   Excessive use of parentheses "()" can clutter the subject line,
   making it harder to quickly grasp the essential message.
+* Avoid conventional commit format (e.g., "chore(scripts):", "feat:", "fix:").
+  These formats waste precious characters from the 50-character limit.
+  Write a direct, descriptive subject instead.
 
 Some conventions are automatically enforced by the [githooks](https://git-scm.com/docs/githooks).
 

--- a/scripts/commit-msg.hook
+++ b/scripts/commit-msg.hook
@@ -404,13 +404,20 @@ validate_commit_message() {
     add_warning 1 "Avoid using parentheses '()' in commit subjects"
   fi
 
-  # 7c. Alert if the commit subject starts with "Implementation"
+  # 7c. Disallow conventional commit format (e.g., "chore(scope):", "feat:", etc.)
+  # These formats waste precious characters from the 50-character limit
+  # Check for patterns like "type:" or "type(scope):" with optional breaking change indicator
+  if [[ ${COMMIT_SUBJECT} =~ ^[a-z]+\([^\)]+\):[[:space:]] ]] || [[ ${COMMIT_SUBJECT} =~ ^[a-z]+!?:[[:space:]] ]]; then
+    add_warning 1 "Avoid conventional commit format (e.g., 'chore(scripts):', 'feat:', 'fix:'). Write a direct, descriptive subject"
+  fi
+
+  # 7d. Alert if the commit subject starts with "Implementation"
   # ------------------------------------------------------------------------------
   if [[ "${COMMIT_SUBJECT_TO_PROCESS}" =~ ^(First|My|Implementation|Implementations|Creation|Modification|Queue) ]]; then
     add_warning 1 "Commit subject should use imperative mood"
   fi
 
-  # 7d. Alert if the commit subject uses the pattern "Implement of ..."
+  # 7e. Alert if the commit subject uses the pattern "Implement of ..."
   if [[ "${COMMIT_SUBJECT_TO_PROCESS}" =~ ^(Implement|Realize|Update|Finish|Code)[[:space:]]+of[[:space:]]+ ]]; then
     add_warning 1 "Avoid using 'of' immediately after the verb"
   fi


### PR DESCRIPTION
Conventional commit formats like 'chore(scripts):', 'feat:', and 'fix(queue):' waste valuable characters from the 50-character subject line limit. These prefixes can consume 10-20 characters, leaving insufficient space for meaningful descriptions.

Contributors should write direct, descriptive subjects that maximize the use of available characters for actual content rather than metadata prefixes.

Change-Id: I981d66a99a8c17987975b473a7f1a5d8cdcccad8