### PR TITLE
Port fmtscan to macOS with location tracking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ qtest: $(OBJS)
 
 fmtscan: tools/fmtscan.c
 ifeq ($(UNAME_S),Darwin)
-	$(Q)printf "#!/usr/bin/env bash\nexit 0\n" > $@
-	$(Q)chmod +x $@
+	$(VECHO) "  CC+LD\t$@\n"
+	$(Q)$(CC) -o $@ $(CFLAGS) -O2 $<
 else
 	$(VECHO) "  CC+LD\t$@\n"
 	$(Q)$(CC) -o $@ $(CFLAGS) $< -lrt -lpthread


### PR DESCRIPTION
This consolidates fmtscan.c to support both Linux and macOS through conditional compilation.
- Add location tracking showing filename:line for each misspelling
- Include comprehensive technical terms dictionary to reduce false positives on macOS where system dictionary lacks programming terms
- Handle platform differences (memory mapping flags, dictionary paths)

Close #265

Change-Id: I37d39960f245ea3984d49a21e7eb3123e0ffd128