### PR TITLE
Fix commit checker false positive for bypassing

### DIFF
--- a/scripts/checksums
+++ b/scripts/checksums
@@ -1,3 +1,3 @@
 25e7d2797e09bfafa0c0dee70111104648faec9d  queue.h
 b26e079496803ebe318174bda5850d2cce1fd0c1  list.h
-c286e18579b6461fc289732cee4a18a916f79659  scripts/check-commitlog.sh
+94041f5a62a086d53799467e1d08e2507a2067b6  scripts/check-commitlog.sh


### PR DESCRIPTION
This replaces broad text matching with targeted 'WIP:' prefix detection to avoid flagging commits that document '--no-verify' functionality.

Change-Id: Iec813848db801be22963403a0a33859886c9240a